### PR TITLE
bump cargo edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 node_modules/
 test-ledger/
 .anchor/
+/programs/uxd/.coderrect/**
+/programs/uxd/target/**
+/programs/uxd/Cargo.lock

--- a/programs/uxd/Cargo.toml
+++ b/programs/uxd/Cargo.toml
@@ -3,7 +3,7 @@ name = "uxd"
 version = "1.0.0"
 authors = ["acammm <alexcamill@gmail.com>"]
 description = "UXDProtocol program for minting and redeeming of UXD tokens."
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
required edition2021 to run soteria 
https://medium.com/coinmonks/soteria-a-vulnerability-scanner-for-solana-smart-contracts-cc202cf17c99
excluded several generated folders from vcs as well during building when running soteria