### PR TITLE
Additional computation to offset unsettled state from mango 

### DIFF
--- a/programs/uxd/src/instructions/mango_dex/mint_with_mango_depository.rs
+++ b/programs/uxd/src/instructions/mango_dex/mint_with_mango_depository.rs
@@ -14,12 +14,11 @@ use mango::state::PerpMarket;
 
 use crate::mango_program;
 use crate::mango_utils::check_effective_order_price_versus_limit_price;
-use crate::mango_utils::check_short_perp_order_fully_filled;
+use crate::mango_utils::check_perp_order_fully_filled;
 use crate::mango_utils::derive_order_delta;
 use crate::mango_utils::get_best_order_for_base_lot_quantity;
-use crate::mango_utils::uncommitted_perp_base_position;
+use crate::mango_utils::total_perp_base_lot_position;
 use crate::mango_utils::Order;
-use crate::mango_utils::OrderDelta;
 use crate::mango_utils::PerpInfo;
 use crate::AccountingEvent;
 use crate::Controller;
@@ -131,14 +130,6 @@ pub fn handler(
     // - [Get perp information]
     let perp_info = ctx.accounts.perpetual_info()?;
 
-    // - [Perp account state PRE perp order]
-    let perp_account = ctx.accounts.perp_account(&perp_info)?;
-
-    // - [Make sure that the PerpAccount crank has been ran previously to this instruction by the uxd-client so that pending changes are updated in mango]
-    if !(perp_account.taker_base == 0 && perp_account.taker_quote == 0) {
-        return Err(ErrorCode::InvalidPerpAccountState.into());
-    }
-
     // - [Get the amount of Base Lots for the perp order]
     let base_lot_amount = I80F48::checked_from_num(collateral_amount)
         .unwrap()
@@ -156,7 +147,7 @@ pub fn handler(
             base_lot_amount.checked_to_num().unwrap(),
         )?;
 
-    // - [Checks that the best price found is withing slippage range]
+    // - [Checks that the best price found is within slippage range]
     check_effective_order_price_versus_limit_price(&perp_info, &best_order, slippage)?;
 
     // - 2 [TRANSFER COLLATERAL TO MANGO (LONG)] ------------------------------
@@ -191,8 +182,11 @@ pub fn handler(
 
     // - 3 [OPEN SHORT PERP] --------------------------------------------------
 
+    // - [Perp account state PRE perp order]
+    let pre_pa = ctx.accounts.perp_account(&perp_info)?;
+
     // - [Base depository's position size in native units PRE perp opening (to calculate the % filled later on)]
-    let initial_base_position = perp_account.base_position;
+    let initial_base_position = total_perp_base_lot_position(&pre_pa);
 
     // - [Place perp order CPI to Mango Market v3]
     mango_program::place_perp_order(
@@ -208,31 +202,44 @@ pub fn handler(
     )?;
 
     // - [Perp account state POST perp order]
-    let perp_account = ctx.accounts.perp_account(&perp_info)?;
+    let post_pa = ctx.accounts.perp_account(&perp_info)?;
 
     // - [Checks that the order was fully filled]
-    let post_position = uncommitted_perp_base_position(&perp_account);
-    check_short_perp_order_fully_filled(best_order.quantity, initial_base_position, post_position)?;
+    let post_perp_order_base_lot_position = total_perp_base_lot_position(&post_pa);
+    check_perp_order_fully_filled(
+        best_order.quantity,
+        initial_base_position,
+        post_perp_order_base_lot_position,
+    )?;
 
-    // - 3[ENSURE MINTING DOESN'T OVERFLOW THE MANGO DEPOSITORIES REDEEMABLE SOFT CAP]
+    // - 3 [ENSURE MINTING DOESN'T OVERFLOW THE MANGO DEPOSITORIES REDEEMABLE SOFT CAP]
 
-    let order_delta = derive_order_delta(&perp_account, &perp_info);
+    // ensure current context make sense as the derive_order_delta is generic
+    assert!(
+        pre_pa.taker_quote.lt(&post_pa.taker_quote),
+        "Invalid order direction"
+    );
+    let order_delta = derive_order_delta(&pre_pa, &post_pa, &perp_info);
+    let redeemable_delta = order_delta.quote.checked_sub(order_delta.fee).unwrap();
+    msg!("redeemable_delta {}", redeemable_delta);
     ctx.accounts
-        .check_mango_depositories_redeemable_soft_cap_overflow(order_delta.redeemable)?;
+        .check_mango_depositories_redeemable_soft_cap_overflow(redeemable_delta)?;
 
     // - 4 [MINTS THE HEDGED AMOUNT OF REDEEMABLE (minus fees)] ---------------
     token::mint_to(
         ctx.accounts
             .into_mint_redeemable_context()
             .with_signer(controller_signer_seed),
-        order_delta.redeemable,
+        redeemable_delta,
     )?;
-
-    // Seems that the display of the mango account doesn't display the fees in the perp pos... investigating
 
     // - 5 [UPDATE ACCOUNTING] ------------------------------------------------
 
-    ctx.accounts.update_onchain_accounting(&order_delta)?;
+    ctx.accounts.update_onchain_accounting(
+        order_delta.collateral,
+        redeemable_delta,
+        order_delta.fee,
+    )?;
 
     // - 6 [ENSURE MINTING DOESN'T OVERFLOW THE GLOBAL REDEEMABLE SUPPLY CAP] -
     ctx.accounts.check_redeemable_global_supply_cap_overflow()?;
@@ -382,19 +389,24 @@ impl<'info> MintWithMangoDepository<'info> {
     }
 
     // Update the accounting in the Depository and Controller Accounts to reflect changes
-    fn update_onchain_accounting(&mut self, order_delta: &OrderDelta) -> UxdResult {
+    fn update_onchain_accounting(
+        &mut self,
+        collateral_delta: u64,
+        redeemable_delta: u64,
+        fee_delta: u64,
+    ) -> UxdResult {
         // Mango Depository
         let event = AccountingEvent::Deposit;
         self.depository
-            .update_collateral_amount_deposited(&event, order_delta.collateral);
+            .update_collateral_amount_deposited(&event, collateral_delta);
         self.depository
-            .update_redeemable_amount_under_management(&event, order_delta.redeemable);
+            .update_redeemable_amount_under_management(&event, redeemable_delta);
         self.depository
-            .update_total_amount_paid_taker_fee(order_delta.fee);
+            .update_total_amount_paid_taker_fee(fee_delta);
 
         // Controller
         self.controller
-            .update_redeemable_circulating_supply(&event, order_delta.redeemable);
+            .update_redeemable_circulating_supply(&event, redeemable_delta);
 
         Ok(())
     }

--- a/programs/uxd/src/mango_utils/limit_utils.rs
+++ b/programs/uxd/src/mango_utils/limit_utils.rs
@@ -5,7 +5,6 @@ use crate::UxdResult;
 use crate::SLIPPAGE_BASIS;
 use fixed::types::I80F48;
 use mango::matching::Side;
-use mango::state::PerpAccount;
 
 // Worse execution price for a provided slippage and side
 pub fn limit_price(price: I80F48, slippage: u32, side: Side) -> I80F48 {
@@ -45,12 +44,4 @@ pub fn check_effective_order_price_versus_limit_price(
         }
     };
     Err(ErrorCode::InvalidSlippage)
-}
-
-// Return the current uncommitted base position for a given PerpAccount
-pub fn uncommitted_perp_base_position(perp_account: &PerpAccount) -> i64 {
-    perp_account
-        .base_position
-        .checked_add(perp_account.taker_base)
-        .unwrap()
 }

--- a/programs/uxd/src/mango_utils/mod.rs
+++ b/programs/uxd/src/mango_utils/mod.rs
@@ -1,9 +1,11 @@
 pub mod limit_utils;
 pub mod order;
 pub mod order_delta;
+pub mod perp_account_utils;
 pub mod perp_info;
 
 pub use limit_utils::*;
 pub use order::*;
 pub use order_delta::*;
+pub use perp_account_utils::*;
 pub use perp_info::*;

--- a/programs/uxd/src/mango_utils/order.rs
+++ b/programs/uxd/src/mango_utils/order.rs
@@ -134,7 +134,7 @@ pub fn get_best_order_for_base_lot_quantity<'a>(
 }
 
 // Verify that the order quantity matches the base position delta
-pub fn check_short_perp_order_fully_filled(
+pub fn check_perp_order_fully_filled(
     order_quantity: i64,
     pre_position: i64,
     post_position: i64,

--- a/programs/uxd/src/mango_utils/order_delta.rs
+++ b/programs/uxd/src/mango_utils/order_delta.rs
@@ -1,3 +1,5 @@
+use crate::mango_utils::total_perp_base_lot_position;
+
 use super::PerpInfo;
 use fixed::types::I80F48;
 use mango::state::PerpAccount;
@@ -5,50 +7,58 @@ use solana_program::msg;
 
 pub struct OrderDelta {
     pub collateral: u64,
-    pub redeemable: u64,
+    pub quote: u64,
     pub fee: u64,
 }
 
 // Note : removes the taker fees from the redeemable_delta.
-//  The fees are not reflected right away in the PerpAccount (uncommitted changes).
+//  The fees are not reflected right away in the PerpAccount (uncommitted changes), so we do it manually.
 //  Mango system needs to call (after this ix, by the user or anyone) the consumeEvents ix, that will process the `fillEvent` in that case
-//  and update all mango internals / resolve the uncommitted balance change, and process fees.
+//  and update all mango internals / resolve the unsettled balance change, and process fees.
 //  The amount minted/redeemed offsets accordingly to reflect that change that will be settled in the future.
-pub fn derive_order_delta(perp_account: &PerpAccount, perp_info: &PerpInfo) -> OrderDelta {
-    let order_value = I80F48::checked_from_num(perp_account.taker_quote)
-        .unwrap()
+pub fn derive_order_delta(
+    pre_pa: &PerpAccount,
+    post_pa: &PerpAccount,
+    perp_info: &PerpInfo,
+) -> OrderDelta {
+    // [QUOTE]
+    // The order delta in quote lot
+    let pre_taker_quote = I80F48::from_num(pre_pa.taker_quote);
+    let post_taker_quote = I80F48::from_num(post_pa.taker_quote);
+    let quote_lot_delta = pre_taker_quote.dist(post_taker_quote);
+
+    assert!(!quote_lot_delta.is_zero(), "quote_lot_delta can't be 0");
+    let quote_delta = I80F48::from_num(quote_lot_delta)
         .checked_mul(perp_info.quote_lot_size)
         .unwrap();
-    // Rounded UP
-    let fee_amount = order_value
+
+    // [QUOTE FEES] (Rounded UP)
+    let fee_amount = quote_delta
         .checked_mul(perp_info.taker_fee)
         .unwrap()
         .checked_ceil()
-        .unwrap()
-        .checked_abs()
         .unwrap();
-    let collateral_amount =
-        I80F48::checked_from_num(perp_account.taker_base.checked_abs().unwrap())
-            .unwrap()
-            .checked_mul(perp_info.base_lot_size)
-            .unwrap();
-    let collateral_delta = collateral_amount.checked_to_num().unwrap();
-    let redeemable_delta = order_value
-        .checked_sub(fee_amount)
-        .unwrap()
-        .checked_abs()
+
+    let fee_delta = fee_amount.checked_to_num().unwrap();
+
+    // [BASE]
+    let pre_base_lot_position = I80F48::from_num(total_perp_base_lot_position(pre_pa));
+    let post_base_lot_position = I80F48::from_num(total_perp_base_lot_position(post_pa));
+    let base_lot_delta = I80F48::from_num(pre_base_lot_position.dist(post_base_lot_position));
+
+    let collateral_delta = base_lot_delta
+        .checked_mul(perp_info.base_lot_size)
         .unwrap()
         .checked_to_num()
         .unwrap();
-    let fee_delta = fee_amount.checked_to_num().unwrap();
 
     msg!("collateral_delta {}", collateral_delta);
-    msg!("redeemable_delta {}", redeemable_delta);
+    msg!("quote_delta {}", quote_delta);
     msg!("fee_delta {}", fee_delta);
 
     OrderDelta {
         collateral: collateral_delta,
-        redeemable: redeemable_delta,
+        quote: quote_delta.checked_to_num().unwrap(),
         fee: fee_delta,
     }
 }

--- a/programs/uxd/src/mango_utils/perp_account_utils.rs
+++ b/programs/uxd/src/mango_utils/perp_account_utils.rs
@@ -1,0 +1,28 @@
+use std::ops::{Mul, Sub};
+
+use fixed::types::I80F48;
+use mango::state::PerpAccount;
+
+use super::PerpInfo;
+
+// Return the base position + the amount that's on EventQueue waiting to be processed
+pub fn total_perp_base_lot_position(perp_account: &PerpAccount) -> i64 {
+    perp_account
+        .base_position
+        .checked_add(perp_account.taker_base)
+        .unwrap()
+}
+
+// Return the quote position + the amount that's on EventQueue waiting to be processed (minus fees)
+pub fn total_perp_quote_position(perp_account: &PerpAccount, perp_info: &PerpInfo) -> i64 {
+    let taker_quote = I80F48::from_num(perp_account.taker_quote)
+        .checked_mul(perp_info.quote_lot_size)
+        .unwrap();
+    let fee_amount = taker_quote.abs().mul(perp_info.taker_fee);
+    let quote_change = taker_quote.sub(fee_amount);
+    let total_quote_position = perp_account
+        .quote_position
+        .checked_add(quote_change)
+        .unwrap();
+    total_quote_position.checked_to_num().unwrap()
+}

--- a/tests/oneshot/mint_wsol.ts
+++ b/tests/oneshot/mint_wsol.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { user } from "../identities";
-import { mintWithMangoDepository, collateralUIPriceInMangoQuote } from "../test_0_uxd_api";
+import { mintWithMangoDepository, collateralUIPriceInMangoQuote, redeemFromMangoDepository, mangoConsumeEvents } from "../test_0_uxd_api";
 import { printUserBalances, printDepositoryInfo, getBalance, userWSOLATA, userUXDATA } from "../integration_test_utils";
 import { slippage } from "../test_2_consts";
 import { depositoryWSOL, mango, slippageBase, controllerUXD } from "../test_0_consts";
@@ -46,5 +46,39 @@ describe(` Just mint ${amountToMint} `, () => {
         expect(amountUxdMinted).closeTo(maxAmountUxdMinted, maxAmountUxdMinted * (slippage), "The amount minted is out of the slippage range");
 
         console.log(`    ==> [Minted ${amountUxdMinted} for ${op_amountWsolUsed} WSOL (prefect was ${maxAmountUxdMinted})]`);
+        await mangoConsumeEvents(depository, mango);
+    });
+
+    it(`mint 10 times`, async () => {
+        let amountRedeemable = 69.69;
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+
+        await mangoConsumeEvents(depository, mango);
     });
 });

--- a/tests/oneshot/wsol_intensive.ts
+++ b/tests/oneshot/wsol_intensive.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import { user } from "../identities";
+import { mintWithMangoDepository, collateralUIPriceInMangoQuote, redeemFromMangoDepository } from "../test_0_uxd_api";
+import { printUserBalances, printDepositoryInfo, getBalance, userUXDATA, getSolBalance } from "../integration_test_utils";
+import { slippage } from "../test_2_consts";
+import { depositoryWSOL, mango, slippageBase, controllerUXD } from "../test_0_consts";
+
+const amountToMint = 1;
+
+describe(` mint ${amountToMint} SOL`, () => {
+    beforeEach("\n", async () => { });
+    afterEach("", async () => {
+        await printUserBalances();
+        await printDepositoryInfo(depositoryWSOL, mango);
+    });
+
+    it(`0 - initial state`, async () => { /* no-op */ });
+
+    const slippagePercentage = slippage / slippageBase;
+
+    const caller = user;
+    const controller = controllerUXD;
+    const depository = depositoryWSOL;
+
+    // OP1
+    let collateralAmount = amountToMint; // in SOL
+    let amountUxdMinted: number;
+    it(`1 - Mint UXD worth ${collateralAmount} SOL with ${slippagePercentage * 100}% max slippage`, async () => {
+        // GIVEN
+        const _userUxdBalancePreOp = await getBalance(userUXDATA);
+        const _userSolBalancePreOp = await getSolBalance(caller.publicKey);
+
+        // WHEN
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+
+        // Then
+        // Could be wrong cause there is a diff between the oracle fetch price and the operation, but let's ignore that for now
+        const maxAmountUxdMinted = (await collateralUIPriceInMangoQuote(depository, mango)) * collateralAmount;
+        const _userUxdBalancePostOp = await getBalance(userUXDATA);
+        const _userSolBalancePostOp = await getSolBalance(caller.publicKey);
+
+        amountUxdMinted = _userUxdBalancePostOp - _userUxdBalancePreOp;
+        const solUsed = _userSolBalancePreOp - _userSolBalancePostOp;
+
+        // + 0.00204 to create wsol ata
+        expect(solUsed).lessThanOrEqual(collateralAmount + 0.00204, "The collateral amount paid doesn't match the user wallet delta");
+        expect(amountUxdMinted).closeTo(maxAmountUxdMinted, maxAmountUxdMinted * (slippage), "The amount minted is out of the slippage range");
+
+        console.log(`    ==> [Minted ${amountUxdMinted} for ${solUsed} SOL (perfect was ${maxAmountUxdMinted})]`);
+    });
+
+    it(`Intensive mint (10)`, async () => {
+        const _userSolBalancePreOp = await getSolBalance(caller.publicKey);
+
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, 1, controller, depository, mango);
+
+        const _userSolBalancePostOp = await getSolBalance(caller.publicKey);
+        const solUsed = _userSolBalancePreOp - _userSolBalancePostOp;
+        // + 0.00204 to create wsol ata
+        expect(solUsed).lessThanOrEqual(10 + 0.00204, "The collateral amount paid doesn't match the user wallet delta");
+    });
+
+    it(`Intensive redeem (10)`, async () => {
+        let amountRedeemable = 100;
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+
+    });
+    it(`Intensive mint/redeem (10)`, async () => {
+        let amountRedeemable = 100;
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+        await redeemFromMangoDepository(caller, slippage, amountRedeemable, controller, depository, mango);
+        await mintWithMangoDepository(caller, slippage, collateralAmount, controller, depository, mango);
+    });
+
+
+
+});


### PR DESCRIPTION
(and remove reliance of `consumeEvents` in the frontend) (#80)

* Take into account the unconsumed events directly in the program to get free from consume events

* move code to perp_account_utils

* use dist

* Fix delta on redeemables

* Changes after review from @mshneider