### PR TITLE
remove proptest compile error

### DIFF
--- a/programs/uxd/proptest-regressions/test/mango_utils/test_order_delta.txt
+++ b/programs/uxd/proptest-regressions/test/mango_utils/test_order_delta.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d3a30e394d2deaed6eb8457f240faa5a808e391803a83b5a2414ed218f567ef9 # shrinks to taker_base = 0, taker_quote = 0, base_position = 0, quote_position = 0, taker_base_post = 0, taker_quote_post = -1, base_position_post = 0, quote_position_post = 0, quote_lot_size = 1
+cc be8c5f3656786c8c0afd633e28b28ecb1322f4d8736610a11407df79232387e1 # shrinks to taker_base = 0, taker_quote = 0, base_position = 0, quote_position = 0, taker_base_post = 0, taker_quote_post = 0, base_position_post = -1, quote_position_post = 0, base_lot_size = 1

--- a/programs/uxd/proptest-regressions/test/mango_utils/test_perp_account_utils.txt
+++ b/programs/uxd/proptest-regressions/test/mango_utils/test_perp_account_utils.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f009ebd31264c6d8dd237af9fee7e7e002f49a907db7b7b329aac7372e8eb26b # shrinks to taker_base = 7986054603602732001, base_position = 1237317433252043807

--- a/programs/uxd/src/test/mango_utils/test_order_delta.rs
+++ b/programs/uxd/src/test/mango_utils/test_order_delta.rs
@@ -26,7 +26,6 @@ mod test_order {
     }
 
     use crate::{
-        error::UxdError,
         mango_utils::{base_delta, quote_delta, taker_fee_amount_ceil},
     };
 
@@ -51,18 +50,7 @@ mod test_order {
                     let expected_quote_delta = I80F48::from_num(taker_quote).dist(I80F48::from_num(taker_quote_post)).checked_mul(quote_lot_size).unwrap();
                     prop_assert_eq!(quote_delta, expected_quote_delta)
                 },
-                Err(error) => {
-                match error {
-                        UxdError::ProgramError(_) => prop_assert!(false),
-                        UxdError::UxdError { uxd_error_code, line: _, source_file_id } => {
-                            prop_assert_eq!(source_file_id, SourceFileId::MangoUtilsLimitUtils);
-                            match uxd_error_code {
-                                UxdError::MathError => prop_assert!(false),
-                                _default => prop_assert!(false)
-                            }
-                        }
-                    }
-                }
+                Err(_error) => prop_assert!(false)
             }
         }
     }
@@ -90,18 +78,7 @@ mod test_order {
                     let expected_base_delta = total_base_pre.dist(I80F48::from_num(total_base_post)).checked_mul(base_lot_size).unwrap();
                     prop_assert_eq!(base_delta, expected_base_delta)
                 },
-                Err(error) => {
-                match error {
-                        UxdError::ProgramError(_) => prop_assert!(false),
-                        UxdError::UxdError { uxd_error_code, line: _, source_file_id } => {
-                            prop_assert_eq!(source_file_id, SourceFileId::MangoUtilsLimitUtils);
-                            match uxd_error_code {
-                                UxdError::MathError => prop_assert!(false),
-                                _default => prop_assert!(false)
-                            }
-                        }
-                    }
-                }
+                Err(_error) => prop_assert!(false)
             }
         }
     }

--- a/programs/uxd/src/test/mango_utils/test_perp_account_utils.rs
+++ b/programs/uxd/src/test/mango_utils/test_perp_account_utils.rs
@@ -2,7 +2,7 @@
 #[cfg(test)]
 mod test_perp_account_utils {
 
-    use crate::{error::UxdError, mango_utils::total_perp_base_lot_position};
+    use crate::{mango_utils::total_perp_base_lot_position};
 
     use fixed::types::I80F48;
     use mango::state::PerpAccount;
@@ -32,18 +32,7 @@ mod test_perp_account_utils {
                 Ok(total) => {
                     prop_assert_eq!(total, taker_base + base_position);
                 }
-                Err(error) => {
-                    match error {
-                        UxdError::ProgramError(_) => prop_assert!(false),
-                        UxdError::UxdError { uxd_error_code, line: _, source_file_id } => {
-                            prop_assert_eq!(source_file_id, SourceFileId::MangoUtilsPerpAccountUtils);
-                            match uxd_error_code {
-                                UxdError::MathError => prop_assert!(true),
-                                _default => prop_assert!(false)
-                            }
-                        }
-                    }
-                }
+                Err(_error) => prop_assert!(false)
             };
         }
     }


### PR DESCRIPTION
just wipe out the error from rust-analyzer about proptest,
`SourceFileId` is remove from this version of program so the assertion is no longer valid

but these proptests are actually failing, these require another fix
