### PR TITLE
disabled default-features for anchor-comp

### DIFF
--- a/programs/uxd/Cargo.toml
+++ b/programs/uxd/Cargo.toml
@@ -26,7 +26,8 @@ spl-token = { version = "3.3.0", features = ["no-entrypoint"] }
 mango = { version = "3.4.3", git = "https://github.com/blockworks-foundation/mango-v3", features = ["no-entrypoint"] }
 anchor-lang = "0.24.2"
 anchor-spl = "0.24.2"
-anchor-comp = { version = "0.1.6", git = "https://github.com/UXDProtocol/anchor-comp", features = ["no-entrypoint", "development"] }
+anchor-comp = { version = "0.1.6", git = "https://github.com/UXDProtocol/anchor-comp", default-features = false, features = ["no-entrypoint", "development"] }
+# anchor-comp = { version = "0.1.6", git = "https://github.com/UXDProtocol/anchor-comp", default-features = false, features = ["no-entrypoint", "production"] }
 fixed = "^1.9.0"
 num-traits = "0.2.14"
 spl-math = { version = "0.1.0", features = ["no-entrypoint"] }


### PR DESCRIPTION
to get rid of the refined ID error when doing production build
<img width="982" alt="Screenshot 2022-05-31 at 2 25 19 AM" src="https://user-images.githubusercontent.com/13584944/171044481-4a64c39d-4f88-4996-9998-70ed3d87df62.png">
 