### PR TITLE
fixed visibility and clippy warnings

### DIFF
--- a/programs/uxd/src/instructions/initialize_controller.rs
+++ b/programs/uxd/src/instructions/initialize_controller.rs
@@ -58,7 +58,10 @@ pub struct InitializeController<'info> {
     pub rent: Sysvar<'info, Rent>,
 }
 
-pub fn handler(ctx: Context<InitializeController>, redeemable_mint_decimals: u8) -> Result<()> {
+pub(crate) fn handler(
+    ctx: Context<InitializeController>,
+    redeemable_mint_decimals: u8,
+) -> Result<()> {
     let controller = &mut ctx.accounts.controller.load_init()?;
     let redeemable_mint_unit = 10_u64
         .checked_pow(redeemable_mint_decimals.into())
@@ -102,7 +105,7 @@ pub fn handler(ctx: Context<InitializeController>, redeemable_mint_decimals: u8)
 // Validate input arguments
 impl<'info> InitializeController<'info> {
     // Asserts that the redeemable mint decimals is between 0 and 9.
-    pub fn validate(&self, decimals: u8) -> Result<()> {
+    pub(crate) fn validate(&self, decimals: u8) -> Result<()> {
         require!(
             decimals <= SOLANA_MAX_MINT_DECIMALS,
             UxdError::InvalidRedeemableMintDecimals

--- a/programs/uxd/src/instructions/mango_dex/deposit_insurance_to_mango_depository.rs
+++ b/programs/uxd/src/instructions/mango_dex/deposit_insurance_to_mango_depository.rs
@@ -86,7 +86,7 @@ pub struct DepositInsuranceToMangoDepository<'info> {
     pub mango_program: Program<'info, MangoMarketV3>,
 }
 
-pub fn handler(ctx: Context<DepositInsuranceToMangoDepository>, amount: u64) -> Result<()> {
+pub(crate) fn handler(ctx: Context<DepositInsuranceToMangoDepository>, amount: u64) -> Result<()> {
     let depository = ctx.accounts.depository.load()?;
     let collateral_mint = depository.collateral_mint;
     let depository_bump = depository.bump;
@@ -101,7 +101,7 @@ pub fn handler(ctx: Context<DepositInsuranceToMangoDepository>, amount: u64) -> 
     // - 1 [DEPOSIT INSURANCE TO MANGO] ---------------------------------------
     mango_markets_v3::deposit(
         ctx.accounts
-            .into_deposit_to_mango_context()
+            .to_deposit_to_mango_context()
             .with_signer(depository_signer_seeds),
         amount,
     )?;
@@ -127,7 +127,7 @@ pub fn handler(ctx: Context<DepositInsuranceToMangoDepository>, amount: u64) -> 
 }
 
 impl<'info> DepositInsuranceToMangoDepository<'info> {
-    pub fn into_deposit_to_mango_context(
+    fn to_deposit_to_mango_context(
         &self,
     ) -> CpiContext<'_, '_, '_, 'info, mango_markets_v3::Deposit<'info>> {
         let cpi_accounts = mango_markets_v3::Deposit {
@@ -147,7 +147,7 @@ impl<'info> DepositInsuranceToMangoDepository<'info> {
 
 // Validate input arguments
 impl<'info> DepositInsuranceToMangoDepository<'info> {
-    pub fn validate(&self, amount: u64) -> Result<()> {
+    pub(crate) fn validate(&self, amount: u64) -> Result<()> {
         require!(amount != 0, UxdError::InvalidInsuranceAmount);
         require!(
             self.authority_quote.amount >= amount,

--- a/programs/uxd/src/instructions/mango_dex/disable_depository_regular_minting.rs
+++ b/programs/uxd/src/instructions/mango_dex/disable_depository_regular_minting.rs
@@ -31,7 +31,7 @@ pub struct DisableDepositoryRegularMinting<'info> {
     pub depository: AccountLoader<'info, MangoDepository>,
 }
 
-pub fn handler(ctx: Context<DisableDepositoryRegularMinting>, disable: bool) -> Result<()> {
+pub(crate) fn handler(ctx: Context<DisableDepositoryRegularMinting>, disable: bool) -> Result<()> {
     let depository = &mut ctx.accounts.depository.load_mut()?;
     depository.regular_minting_disabled = disable;
     Ok(())
@@ -39,7 +39,7 @@ pub fn handler(ctx: Context<DisableDepositoryRegularMinting>, disable: bool) -> 
 
 // Validate input arguments
 impl<'info> DisableDepositoryRegularMinting<'info> {
-    pub fn validate(&self, disable: bool) -> Result<()> {
+    pub(crate) fn validate(&self, disable: bool) -> Result<()> {
         require!(
             self.depository.load()?.regular_minting_disabled != disable,
             UxdError::MintingAlreadyDisabledOrEnabled

--- a/programs/uxd/src/instructions/mango_dex/quote_redeem_from_mango_depository.rs
+++ b/programs/uxd/src/instructions/mango_dex/quote_redeem_from_mango_depository.rs
@@ -16,7 +16,6 @@ use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token;
 use anchor_spl::token::Burn;
 use anchor_spl::token::Mint;
-use anchor_spl::token::MintTo;
 use anchor_spl::token::Token;
 use anchor_spl::token::TokenAccount;
 use fixed::types::I80F48;
@@ -143,7 +142,10 @@ pub struct QuoteRedeemFromMangoDepository<'info> {
     pub rent: Sysvar<'info, Rent>,
 }
 
-pub fn handler(ctx: Context<QuoteRedeemFromMangoDepository>, redeemable_amount: u64) -> Result<()> {
+pub(crate) fn handler(
+    ctx: Context<QuoteRedeemFromMangoDepository>,
+    redeemable_amount: u64,
+) -> Result<()> {
     let depository = ctx.accounts.depository.load()?;
     let depository_signer_seed: &[&[&[u8]]] = &[&[
         MANGO_DEPOSITORY_NAMESPACE,
@@ -224,7 +226,7 @@ pub fn handler(ctx: Context<QuoteRedeemFromMangoDepository>, redeemable_amount: 
     // - 3 [BURN USER'S REDEEMABLE] -------------------------------------------
     // Burn will fail if user does not have enough redeemable
     token::burn(
-        ctx.accounts.into_burn_redeemable_context(),
+        ctx.accounts.to_burn_redeemable_context(),
         redeemable_amount,
     )?;
 
@@ -253,7 +255,7 @@ pub fn handler(ctx: Context<QuoteRedeemFromMangoDepository>, redeemable_amount: 
 
     mango_markets_v3::withdraw(
         ctx.accounts
-            .into_withdraw_quote_mint_from_mango_context()
+            .to_withdraw_quote_mint_from_mango_context()
             .with_signer(depository_signer_seed),
         quote_withdraw_amount_less_fees,
         false,
@@ -268,7 +270,9 @@ pub fn handler(ctx: Context<QuoteRedeemFromMangoDepository>, redeemable_amount: 
 }
 
 impl<'info> QuoteRedeemFromMangoDepository<'info> {
-    pub fn into_burn_redeemable_context(&self) -> CpiContext<'_, '_, '_, 'info, Burn<'info>> {
+    fn to_burn_redeemable_context(
+        &self,
+    ) -> CpiContext<'_, '_, '_, 'info, Burn<'info>> {
         let cpi_program = self.token_program.to_account_info();
         let cpi_accounts = Burn {
             mint: self.redeemable_mint.to_account_info(),
@@ -278,7 +282,7 @@ impl<'info> QuoteRedeemFromMangoDepository<'info> {
         CpiContext::new(cpi_program, cpi_accounts)
     }
 
-    pub fn into_withdraw_quote_mint_from_mango_context(
+    fn to_withdraw_quote_mint_from_mango_context(
         &self,
     ) -> CpiContext<'_, '_, '_, 'info, mango_markets_v3::Withdraw<'info>> {
         let cpi_accounts = mango_markets_v3::Withdraw {
@@ -293,16 +297,6 @@ impl<'info> QuoteRedeemFromMangoDepository<'info> {
             signer: self.mango_signer.to_account_info(),
         };
         let cpi_program = self.mango_program.to_account_info();
-        CpiContext::new(cpi_program, cpi_accounts)
-    }
-
-    pub fn into_mint_redeemable_context(&self) -> CpiContext<'_, '_, '_, 'info, MintTo<'info>> {
-        let cpi_program = self.token_program.to_account_info();
-        let cpi_accounts = MintTo {
-            mint: self.redeemable_mint.to_account_info(),
-            to: self.user_redeemable.to_account_info(),
-            authority: self.controller.to_account_info(),
-        };
         CpiContext::new(cpi_program, cpi_accounts)
     }
 
@@ -370,7 +364,7 @@ impl<'info> QuoteRedeemFromMangoDepository<'info> {
 
 // Validate input arguments
 impl<'info> QuoteRedeemFromMangoDepository<'info> {
-    pub fn validate(&self, redeemable_amount: u64) -> Result<()> {
+    pub(crate) fn validate(&self, redeemable_amount: u64) -> Result<()> {
         require!(redeemable_amount != 0, UxdError::InvalidRedeemableAmount);
         validate_perp_market_mints_matches_depository_mints(
             &self.mango_group,

--- a/programs/uxd/src/instructions/mango_dex/withdraw_insurance_from_mango_depository.rs
+++ b/programs/uxd/src/instructions/mango_dex/withdraw_insurance_from_mango_depository.rs
@@ -92,7 +92,10 @@ pub struct WithdrawInsuranceFromMangoDepository<'info> {
     pub mango_program: Program<'info, MangoMarketV3>,
 }
 
-pub fn handler(ctx: Context<WithdrawInsuranceFromMangoDepository>, amount: u64) -> Result<()> {
+pub(crate) fn handler(
+    ctx: Context<WithdrawInsuranceFromMangoDepository>,
+    amount: u64,
+) -> Result<()> {
     let depository = ctx.accounts.depository.load()?;
     let collateral_mint = depository.collateral_mint;
     let depository_bump = depository.bump;
@@ -109,7 +112,7 @@ pub fn handler(ctx: Context<WithdrawInsuranceFromMangoDepository>, amount: u64) 
     // - mango withdraw insurance_amount
     mango_markets_v3::withdraw(
         ctx.accounts
-            .into_withdraw_insurance_from_mango_context()
+            .to_withdraw_insurance_from_mango_context()
             .with_signer(depository_signer_seed),
         amount,
         false,
@@ -136,7 +139,7 @@ pub fn handler(ctx: Context<WithdrawInsuranceFromMangoDepository>, amount: u64) 
 }
 
 impl<'info> WithdrawInsuranceFromMangoDepository<'info> {
-    pub fn into_withdraw_insurance_from_mango_context(
+    fn to_withdraw_insurance_from_mango_context(
         &self,
     ) -> CpiContext<'_, '_, '_, 'info, mango_markets_v3::Withdraw<'info>> {
         let cpi_accounts = mango_markets_v3::Withdraw {
@@ -157,7 +160,7 @@ impl<'info> WithdrawInsuranceFromMangoDepository<'info> {
 
 // Validate input arguments
 impl<'info> WithdrawInsuranceFromMangoDepository<'info> {
-    pub fn validate(&self, insurance_amount: u64) -> Result<()> {
+    pub(crate) fn validate(&self, insurance_amount: u64) -> Result<()> {
         require!(insurance_amount != 0, UxdError::InvalidInsuranceAmount);
         // Mango withdraw will fail with proper error thanks to  `disabled borrow` set to true if the balance is not enough.
         Ok(())

--- a/programs/uxd/src/instructions/register_mango_depository.rs
+++ b/programs/uxd/src/instructions/register_mango_depository.rs
@@ -82,7 +82,7 @@ pub struct RegisterMangoDepository<'info> {
     pub rent: Sysvar<'info, Rent>,
 }
 
-pub fn handler(ctx: Context<RegisterMangoDepository>) -> Result<()> {
+pub(crate) fn handler(ctx: Context<RegisterMangoDepository>) -> Result<()> {
     let collateral_mint = ctx.accounts.collateral_mint.key();
     let quote_mint = ctx.accounts.quote_mint.key();
 
@@ -99,7 +99,7 @@ pub fn handler(ctx: Context<RegisterMangoDepository>) -> Result<()> {
     ]];
     mango_markets_v3::init_mango_account(
         ctx.accounts
-            .into_mango_init_account_context()
+            .to_mango_init_account_context()
             .with_signer(depository_signer_seed),
     )?;
 
@@ -145,7 +145,7 @@ pub fn handler(ctx: Context<RegisterMangoDepository>) -> Result<()> {
 }
 
 impl<'info> RegisterMangoDepository<'info> {
-    pub fn into_mango_init_account_context(
+    fn to_mango_init_account_context(
         &self,
     ) -> CpiContext<'_, '_, '_, 'info, mango_markets_v3::InitMangoAccount<'info>> {
         let cpi_accounts = mango_markets_v3::InitMangoAccount {

--- a/programs/uxd/src/instructions/set_mango_depositories_redeemable_soft_cap.rs
+++ b/programs/uxd/src/instructions/set_mango_depositories_redeemable_soft_cap.rs
@@ -21,7 +21,7 @@ pub struct SetMangoDepositoriesRedeemableSoftCap<'info> {
     pub controller: AccountLoader<'info, Controller>,
 }
 
-pub fn handler(
+pub(crate) fn handler(
     ctx: Context<SetMangoDepositoriesRedeemableSoftCap>,
     redeemable_soft_cap: u64,
 ) -> Result<()> {
@@ -41,7 +41,7 @@ pub fn handler(
 #[allow(clippy::absurd_extreme_comparisons)]
 impl<'info> SetMangoDepositoriesRedeemableSoftCap<'info> {
     // Asserts that the Mango Depositories redeemable soft cap is between 0 and MAX_REDEEMABLE_GLOBAL_SUPPLY_CAP.
-    pub fn validate(&self, redeemable_soft_cap: u64) -> Result<()> {
+    pub(crate) fn validate(&self, redeemable_soft_cap: u64) -> Result<()> {
         require!(
             redeemable_soft_cap <= MAX_MANGO_DEPOSITORIES_REDEEMABLE_SOFT_CAP,
             UxdError::InvalidMangoDepositoriesRedeemableSoftCap

--- a/programs/uxd/src/instructions/set_mango_depository_quote_mint_and_redeem_fee.rs
+++ b/programs/uxd/src/instructions/set_mango_depository_quote_mint_and_redeem_fee.rs
@@ -32,7 +32,7 @@ pub struct SetMangoDepositoryQuoteMintAndRedeemFee<'info> {
     pub depository: AccountLoader<'info, MangoDepository>,
 }
 
-pub fn handler(
+pub(crate) fn handler(
     ctx: Context<SetMangoDepositoryQuoteMintAndRedeemFee>,
     quote_fee: u8, // in bps
 ) -> Result<()> {

--- a/programs/uxd/src/instructions/set_mango_depository_quote_mint_and_redeem_soft_cap.rs
+++ b/programs/uxd/src/instructions/set_mango_depository_quote_mint_and_redeem_soft_cap.rs
@@ -19,7 +19,7 @@ pub struct SetMangoDepositoryQuoteMintAndRedeemSoftCap<'info> {
     pub controller: AccountLoader<'info, Controller>,
 }
 
-pub fn handler(
+pub(crate) fn handler(
     ctx: Context<SetMangoDepositoryQuoteMintAndRedeemSoftCap>,
     quote_redeemable_soft_cap: u64, // in redeemable native units
 ) -> Result<()> {

--- a/programs/uxd/src/instructions/set_redeemable_global_supply_cap.rs
+++ b/programs/uxd/src/instructions/set_redeemable_global_supply_cap.rs
@@ -21,7 +21,7 @@ pub struct SetRedeemableGlobalSupplyCap<'info> {
     pub controller: AccountLoader<'info, Controller>,
 }
 
-pub fn handler(
+pub(crate) fn handler(
     ctx: Context<SetRedeemableGlobalSupplyCap>,
     redeemable_global_supply_cap: u128,
 ) -> Result<()> {
@@ -39,7 +39,7 @@ pub fn handler(
 #[allow(clippy::absurd_extreme_comparisons)]
 impl<'info> SetRedeemableGlobalSupplyCap<'info> {
     // Asserts that the redeemable global supply cap is between 0 and MAX_REDEEMABLE_GLOBAL_SUPPLY_CAP.
-    pub fn validate(&self, redeemable_global_supply_cap: u128) -> Result<()> {
+    pub(crate) fn validate(&self, redeemable_global_supply_cap: u128) -> Result<()> {
         require!(
             redeemable_global_supply_cap <= MAX_REDEEMABLE_GLOBAL_SUPPLY_CAP,
             UxdError::InvalidRedeemableGlobalSupplyCap

--- a/programs/uxd/src/mango_utils/mod.rs
+++ b/programs/uxd/src/mango_utils/mod.rs
@@ -3,5 +3,5 @@ pub mod perp_account_utils;
 pub mod perp_info;
 
 pub use order_delta::*;
-pub use perp_account_utils::*;
+pub(crate) use perp_account_utils::*;
 pub use perp_info::*;

--- a/programs/uxd/src/mango_utils/order_delta.rs
+++ b/programs/uxd/src/mango_utils/order_delta.rs
@@ -15,7 +15,7 @@ pub struct OrderDelta {
 }
 
 // Quote delta between two states of perp account
-pub fn quote_delta(
+pub(crate) fn quote_delta(
     pre_pa: &PerpAccount,
     post_pa: &PerpAccount,
     quote_lot_size: I80F48,
@@ -31,7 +31,7 @@ pub fn quote_delta(
 }
 
 // Quote delta between two states of perp account
-pub fn base_delta(
+pub(crate) fn base_delta(
     pre_pa: &PerpAccount,
     post_pa: &PerpAccount,
     base_lot_size: I80F48,
@@ -47,20 +47,20 @@ pub fn base_delta(
 }
 
 // returns the amount of taker_fee paid for trading raw_quote_amount (rounded up)
-pub fn taker_fee_amount_ceil(raw_quote_amount: I80F48, taker_fee: I80F48) -> Result<I80F48> {
+pub(crate) fn taker_fee_amount_ceil(raw_quote_amount: I80F48, taker_fee: I80F48) -> Result<I80F48> {
     let fee_amount = raw_quote_amount
         .checked_mul(taker_fee)
         .ok_or_else(|| error!(UxdError::MathError))?;
     // The absolute amount of fee paid must always be rounded up in the business logic
     // hence the sign being taken into consideration
-    return match fee_amount.is_positive() {
+    match fee_amount.is_positive() {
         true => fee_amount
             .checked_ceil()
             .ok_or_else(|| error!(UxdError::MathError)),
         false => fee_amount
             .checked_floor()
             .ok_or_else(|| error!(UxdError::MathError)),
-    };
+    }
 }
 
 // Note : removes the taker fees from the redeemable_delta.
@@ -69,7 +69,7 @@ pub fn taker_fee_amount_ceil(raw_quote_amount: I80F48, taker_fee: I80F48) -> Res
 //  and update all mango internals / resolve the unsettled balance change, and process fees.
 //  The amount minted/redeemed offsets accordingly to reflect that change that will be settled in the future.
 // MangoMarkets v3.3.5 : Fees are now reflected directly in the quote_position, still not in the taker_quote
-pub fn derive_order_delta(
+pub(crate) fn derive_order_delta(
     pre_pa: &PerpAccount,
     post_pa: &PerpAccount,
     perp_info: &PerpInfo,

--- a/programs/uxd/src/mango_utils/perp_account_utils.rs
+++ b/programs/uxd/src/mango_utils/perp_account_utils.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use mango::state::PerpAccount;
 
 // Return the base position + the amount that's on EventQueue waiting to be processed
-pub fn total_perp_base_lot_position(perp_account: &PerpAccount) -> Result<i64> {
+pub(crate) fn total_perp_base_lot_position(perp_account: &PerpAccount) -> Result<i64> {
     perp_account
         .base_position
         .checked_add(perp_account.taker_base)

--- a/programs/uxd/src/mango_utils/perp_info.rs
+++ b/programs/uxd/src/mango_utils/perp_info.rs
@@ -23,7 +23,7 @@ pub struct PerpInfo {
 
 impl PerpInfo {
     // Make sure that this is called in an instruction where a Mango CPI that validate cache is also called, else the cache may be not up to date.
-    pub fn new(
+    pub(crate) fn new(
         mango_group_ai: &AccountInfo,
         mango_cache_ai: &AccountInfo,
         mango_account_ai: &AccountInfo,
@@ -49,7 +49,7 @@ impl PerpInfo {
         )
     }
 
-    pub fn init(
+    fn init(
         mango_group: &MangoGroup,
         mango_account: &MangoAccount,
         mango_cache: &MangoCache,
@@ -98,7 +98,7 @@ fn determine_ref_fee(
 
 // Convert price into a quote lot per base lot price.
 // Price is the value of 1 native base unit expressed in native quote.
-pub fn price_to_lot_price(price: I80F48, perp_info: &PerpInfo) -> Result<I80F48> {
+pub(crate) fn price_to_lot_price(price: I80F48, perp_info: &PerpInfo) -> Result<I80F48> {
     price
         .checked_mul(perp_info.base_lot_size)
         .ok_or_else(|| error!(UxdError::MathError))?

--- a/programs/uxd/src/state/controller.rs
+++ b/programs/uxd/src/state/controller.rs
@@ -55,7 +55,7 @@ pub struct Controller {
 }
 
 impl Controller {
-    pub fn add_registered_mango_depository_entry(
+    pub(crate) fn add_registered_mango_depository_entry(
         &mut self,
         mango_depository_id: Pubkey,
     ) -> Result<()> {


### PR DESCRIPTION
- convert visibility of `pub fn` to either `pub(crate) fn` or `fn`, it brings back the clippy warning about dead code if there are any (all fn in lib.rs remained as pub fn since it's a public api)
- rename `into_` to just `to_` according to https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention since it takes a Borrowed self and output a smthg Owned

these clean up all to the warning from clippy