### PR TITLE
[Mercurial] profits beneficiary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@project-serum/anchor": "0.24.2",
         "@solana/spl-token": "^0.1.8",
         "@solana/web3.js": "1.39.1",
-        "@uxd-protocol/uxd-client": "6.3.0-profits-mercurial-rc2"
+        "@uxd-protocol/uxd-client": "6.3.0-profits-mercurial-rc5"
       },
       "devDependencies": {
         "@types/chai": "^4.3.0",
@@ -3847,9 +3847,9 @@
       "dev": true
     },
     "node_modules/@uxd-protocol/uxd-client": {
-      "version": "6.3.0-profits-mercurial-rc2",
-      "resolved": "https://registry.npmjs.org/@uxd-protocol/uxd-client/-/uxd-client-6.3.0-profits-mercurial-rc2.tgz",
-      "integrity": "sha512-fb71GwUa+dKmpBKCjrpfBBeqvwsiQ5J6xbPbJWTbaD1798hs3hd0aS/+zsxBrt5R00tzuBN6X4UkJPUea08yhg==",
+      "version": "6.3.0-profits-mercurial-rc5",
+      "resolved": "https://registry.npmjs.org/@uxd-protocol/uxd-client/-/uxd-client-6.3.0-profits-mercurial-rc5.tgz",
+      "integrity": "sha512-EbjgTXTgfGtPOIYagvl4ODtHPszW26i74f88daidpTGTUHOvcua4TfPTX5kwlu1eGeABw59WWLNFqxNlMCQ5pw==",
       "dependencies": {
         "@project-serum/anchor": "0.24.2",
         "@solana/spl-token": "0.1.8",
@@ -14565,9 +14565,9 @@
       "dev": true
     },
     "@uxd-protocol/uxd-client": {
-      "version": "6.3.0-profits-mercurial-rc2",
-      "resolved": "https://registry.npmjs.org/@uxd-protocol/uxd-client/-/uxd-client-6.3.0-profits-mercurial-rc2.tgz",
-      "integrity": "sha512-fb71GwUa+dKmpBKCjrpfBBeqvwsiQ5J6xbPbJWTbaD1798hs3hd0aS/+zsxBrt5R00tzuBN6X4UkJPUea08yhg==",
+      "version": "6.3.0-profits-mercurial-rc5",
+      "resolved": "https://registry.npmjs.org/@uxd-protocol/uxd-client/-/uxd-client-6.3.0-profits-mercurial-rc5.tgz",
+      "integrity": "sha512-EbjgTXTgfGtPOIYagvl4ODtHPszW26i74f88daidpTGTUHOvcua4TfPTX5kwlu1eGeABw59WWLNFqxNlMCQ5pw==",
       "requires": {
         "@project-serum/anchor": "0.24.2",
         "@solana/spl-token": "0.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@project-serum/anchor": "0.24.2",
         "@solana/spl-token": "^0.1.8",
         "@solana/web3.js": "1.39.1",
-        "@uxd-protocol/uxd-client": "6.3.0-profits-mercurial-rc1"
+        "@uxd-protocol/uxd-client": "6.3.0-profits-mercurial-rc2"
       },
       "devDependencies": {
         "@types/chai": "^4.3.0",
@@ -3847,9 +3847,9 @@
       "dev": true
     },
     "node_modules/@uxd-protocol/uxd-client": {
-      "version": "6.3.0-profits-mercurial-rc1",
-      "resolved": "https://registry.npmjs.org/@uxd-protocol/uxd-client/-/uxd-client-6.3.0-profits-mercurial-rc1.tgz",
-      "integrity": "sha512-gD8AIf9DES8YnCuVUq8/7sJbCru1CHemOgFcpudSPeHhdFfyFkWkEqgLwDMhQiJlKON9bXKZQi0JUX/Qk646PQ==",
+      "version": "6.3.0-profits-mercurial-rc2",
+      "resolved": "https://registry.npmjs.org/@uxd-protocol/uxd-client/-/uxd-client-6.3.0-profits-mercurial-rc2.tgz",
+      "integrity": "sha512-fb71GwUa+dKmpBKCjrpfBBeqvwsiQ5J6xbPbJWTbaD1798hs3hd0aS/+zsxBrt5R00tzuBN6X4UkJPUea08yhg==",
       "dependencies": {
         "@project-serum/anchor": "0.24.2",
         "@solana/spl-token": "0.1.8",
@@ -14565,9 +14565,9 @@
       "dev": true
     },
     "@uxd-protocol/uxd-client": {
-      "version": "6.3.0-profits-mercurial-rc1",
-      "resolved": "https://registry.npmjs.org/@uxd-protocol/uxd-client/-/uxd-client-6.3.0-profits-mercurial-rc1.tgz",
-      "integrity": "sha512-gD8AIf9DES8YnCuVUq8/7sJbCru1CHemOgFcpudSPeHhdFfyFkWkEqgLwDMhQiJlKON9bXKZQi0JUX/Qk646PQ==",
+      "version": "6.3.0-profits-mercurial-rc2",
+      "resolved": "https://registry.npmjs.org/@uxd-protocol/uxd-client/-/uxd-client-6.3.0-profits-mercurial-rc2.tgz",
+      "integrity": "sha512-fb71GwUa+dKmpBKCjrpfBBeqvwsiQ5J6xbPbJWTbaD1798hs3hd0aS/+zsxBrt5R00tzuBN6X4UkJPUea08yhg==",
       "requires": {
         "@project-serum/anchor": "0.24.2",
         "@solana/spl-token": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@project-serum/anchor": "0.24.2",
     "@solana/spl-token": "^0.1.8",
     "@solana/web3.js": "1.39.1",
-    "@uxd-protocol/uxd-client": "6.3.0-profits-mercurial-rc2"
+    "@uxd-protocol/uxd-client": "6.3.0-profits-mercurial-rc5"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@project-serum/anchor": "0.24.2",
     "@solana/spl-token": "^0.1.8",
     "@solana/web3.js": "1.39.1",
-    "@uxd-protocol/uxd-client": "6.3.0-profits-mercurial-rc1"
+    "@uxd-protocol/uxd-client": "6.3.0-profits-mercurial-rc2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",

--- a/programs/uxd/src/error.rs
+++ b/programs/uxd/src/error.rs
@@ -76,7 +76,9 @@ pub enum UxdError {
     InvalidDepositoryShares,
     #[msg("The Profits beneficiary provided does not match the depository's one.")]
     InvalidProfitsBeneficiary,
-    #[msg("The provided mercurial vault does not match the Depository's one.")]
+    #[msg("The Profits beneficiary provided does not match the depository's one.")]
+    ProfitsBeneficiaryNotInitialized,
+    #[msg("The profits beneficiary hasn't setup for this depository")]
     InvalidMercurialVault,
     #[msg("The provided mercurial vault collateral token safe does not match the mercurial vault one.")]
     InvalidMercurialVaultCollateralTokenSafe,

--- a/programs/uxd/src/error.rs
+++ b/programs/uxd/src/error.rs
@@ -74,6 +74,8 @@ pub enum UxdError {
     InvalidDepositoryCollateral,
     #[msg("The provided depository shares does not match the depository's one.")]
     InvalidDepositoryShares,
+    #[msg("The Profits beneficiary provided does not match the depository's one.")]
+    InvalidProfitsBeneficiary,
     #[msg("The provided mercurial vault does not match the Depository's one.")]
     InvalidMercurialVault,
     #[msg("The provided mercurial vault collateral token safe does not match the mercurial vault one.")]

--- a/programs/uxd/src/error.rs
+++ b/programs/uxd/src/error.rs
@@ -74,10 +74,10 @@ pub enum UxdError {
     InvalidDepositoryCollateral,
     #[msg("The provided depository shares does not match the depository's one.")]
     InvalidDepositoryShares,
-    #[msg("The Profits beneficiary provided does not match the depository's one.")]
-    InvalidProfitsBeneficiary,
-    #[msg("The Profits beneficiary provided does not match the depository's one.")]
-    ProfitsBeneficiaryNotInitialized,
+    #[msg("The Profits beneficiary collateral provided does not match the depository's one.")]
+    InvalidProfitsBeneficiaryCollateral,
+    #[msg("The Profits beneficiary collateral provided is set to an invalid value.")]
+    UninitializedProfitsBeneficiaryCollateral,
     #[msg("The profits beneficiary hasn't setup for this depository")]
     InvalidMercurialVault,
     #[msg("The provided mercurial vault collateral token safe does not match the mercurial vault one.")]

--- a/programs/uxd/src/events.rs
+++ b/programs/uxd/src/events.rs
@@ -96,6 +96,19 @@ pub struct SetDepositoryMintingDisabledEvent {
     pub minting_disabled: bool,
 }
 
+/// Event called in [instructions::edit_*_depository::handler].
+#[event]
+pub struct SetDepositoryProfitsBeneficiaryKeyEvent {
+    #[index]
+    pub version: u8,
+    #[index]
+    pub controller: Pubkey,
+    #[index]
+    pub depository: Pubkey,
+    #[index]
+    pub profits_beneficiary_key: Pubkey,
+}
+
 /// Event called in [instructions::initialize_identity_depository::handler].
 #[event]
 pub struct InitializeIdentityDepositoryEvent {

--- a/programs/uxd/src/events.rs
+++ b/programs/uxd/src/events.rs
@@ -106,7 +106,7 @@ pub struct SetDepositoryProfitsBeneficiaryKeyEvent {
     #[index]
     pub depository: Pubkey,
     #[index]
-    pub profits_beneficiary_key: Pubkey,
+    pub profits_beneficiary_collateral: Pubkey,
 }
 
 /// Event called in [instructions::initialize_identity_depository::handler].

--- a/programs/uxd/src/events.rs
+++ b/programs/uxd/src/events.rs
@@ -98,7 +98,7 @@ pub struct SetDepositoryMintingDisabledEvent {
 
 /// Event called in [instructions::edit_*_depository::handler].
 #[event]
-pub struct SetDepositoryProfitsBeneficiaryKeyEvent {
+pub struct SetDepositoryProfitsBeneficiaryCollateralEvent {
     #[index]
     pub version: u8,
     #[index]

--- a/programs/uxd/src/instructions/edit_mercurial_vault_depository.rs
+++ b/programs/uxd/src/instructions/edit_mercurial_vault_depository.rs
@@ -1,6 +1,7 @@
 use crate::error::UxdError;
 use crate::events::SetDepositoryMintingDisabledEvent;
 use crate::events::SetDepositoryMintingFeeInBpsEvent;
+use crate::events::SetDepositoryProfitsBeneficiaryKeyEvent;
 use crate::events::SetDepositoryRedeemableAmountUnderManagementCapEvent;
 use crate::events::SetDepositoryRedeemingFeeInBpsEvent;
 use crate::state::mercurial_vault_depository::MercurialVaultDepository;
@@ -42,6 +43,7 @@ pub struct EditMercurialVaultDepositoryFields {
     minting_fee_in_bps: Option<u8>,
     redeeming_fee_in_bps: Option<u8>,
     minting_disabled: Option<bool>,
+    profits_beneficiary_key: Option<Pubkey>,
 }
 
 pub(crate) fn handler(
@@ -109,6 +111,21 @@ pub(crate) fn handler(
             controller: ctx.accounts.controller.key(),
             depository: ctx.accounts.depository.key(),
             minting_disabled
+        });
+    }
+
+    // optional: profits_beneficiary_key
+    if let Some(profits_beneficiary_key) = fields.profits_beneficiary_key {
+        msg!(
+            "[edit_mercurial_vault_depository] profits_beneficiary_key {}",
+            profits_beneficiary_key
+        );
+        depository.profits_beneficiary_key = profits_beneficiary_key;
+        emit!(SetDepositoryProfitsBeneficiaryKeyEvent {
+            version: ctx.accounts.controller.load()?.version,
+            controller: ctx.accounts.controller.key(),
+            depository: ctx.accounts.depository.key(),
+            profits_beneficiary_key
         });
     }
 

--- a/programs/uxd/src/instructions/edit_mercurial_vault_depository.rs
+++ b/programs/uxd/src/instructions/edit_mercurial_vault_depository.rs
@@ -1,7 +1,7 @@
 use crate::error::UxdError;
 use crate::events::SetDepositoryMintingDisabledEvent;
 use crate::events::SetDepositoryMintingFeeInBpsEvent;
-use crate::events::SetDepositoryProfitsBeneficiaryKeyEvent;
+use crate::events::SetDepositoryProfitsBeneficiaryCollateralEvent;
 use crate::events::SetDepositoryRedeemableAmountUnderManagementCapEvent;
 use crate::events::SetDepositoryRedeemingFeeInBpsEvent;
 use crate::state::mercurial_vault_depository::MercurialVaultDepository;
@@ -121,7 +121,7 @@ pub(crate) fn handler(
             profits_beneficiary_collateral
         );
         depository.profits_beneficiary_collateral = profits_beneficiary_collateral;
-        emit!(SetDepositoryProfitsBeneficiaryKeyEvent {
+        emit!(SetDepositoryProfitsBeneficiaryCollateralEvent {
             version: ctx.accounts.controller.load()?.version,
             controller: ctx.accounts.controller.key(),
             depository: ctx.accounts.depository.key(),

--- a/programs/uxd/src/instructions/edit_mercurial_vault_depository.rs
+++ b/programs/uxd/src/instructions/edit_mercurial_vault_depository.rs
@@ -43,7 +43,7 @@ pub struct EditMercurialVaultDepositoryFields {
     minting_fee_in_bps: Option<u8>,
     redeeming_fee_in_bps: Option<u8>,
     minting_disabled: Option<bool>,
-    profits_beneficiary_key: Option<Pubkey>,
+    profits_beneficiary_collateral: Option<Pubkey>,
 }
 
 pub(crate) fn handler(
@@ -114,18 +114,18 @@ pub(crate) fn handler(
         });
     }
 
-    // optional: profits_beneficiary_key
-    if let Some(profits_beneficiary_key) = fields.profits_beneficiary_key {
+    // optional: profits_beneficiary_collateral
+    if let Some(profits_beneficiary_collateral) = fields.profits_beneficiary_collateral {
         msg!(
-            "[edit_mercurial_vault_depository] profits_beneficiary_key {}",
-            profits_beneficiary_key
+            "[edit_mercurial_vault_depository] profits_beneficiary_collateral {}",
+            profits_beneficiary_collateral
         );
-        depository.profits_beneficiary_key = profits_beneficiary_key;
+        depository.profits_beneficiary_collateral = profits_beneficiary_collateral;
         emit!(SetDepositoryProfitsBeneficiaryKeyEvent {
             version: ctx.accounts.controller.load()?.version,
             controller: ctx.accounts.controller.key(),
             depository: ctx.accounts.depository.key(),
-            profits_beneficiary_key
+            profits_beneficiary_collateral
         });
     }
 

--- a/programs/uxd/src/instructions/mercurial/collect_profit_of_mercurial_vault_depository.rs
+++ b/programs/uxd/src/instructions/mercurial/collect_profit_of_mercurial_vault_depository.rs
@@ -1,5 +1,6 @@
 use crate::error::UxdError;
 use crate::mercurial_utils;
+use crate::validate_is_program_frozen;
 use crate::Controller;
 use crate::MercurialVaultDepository;
 use crate::CONTROLLER_NAMESPACE;
@@ -284,6 +285,14 @@ impl<'info> CollectProfitOfMercurialVaultDepository<'info> {
             UxdError::SlippageReached,
         );
 
+        Ok(())
+    }
+}
+
+// Validate
+impl<'info> CollectProfitOfMercurialVaultDepository<'info> {
+    pub(crate) fn validate(&self) -> Result<()> {
+        validate_is_program_frozen(self.controller.load()?)?;
         Ok(())
     }
 }

--- a/programs/uxd/src/lib.rs
+++ b/programs/uxd/src/lib.rs
@@ -259,6 +259,9 @@ pub mod uxd {
         instructions::freeze_program::handler(ctx, freeze)
     }
 
+    #[access_control(
+        ctx.accounts.validate()
+    )]
     pub fn collect_profit_of_mercurial_vault_depository(
         ctx: Context<CollectProfitOfMercurialVaultDepository>,
     ) -> Result<()> {

--- a/programs/uxd/src/state/mercurial_vault_depository.rs
+++ b/programs/uxd/src/state/mercurial_vault_depository.rs
@@ -93,7 +93,7 @@ pub struct MercurialVaultDepository {
     pub last_profits_collection_unix_timestamp: u64,
 
     // Receiver of the depository's profits
-    pub profits_beneficiary_key: Pubkey,
+    pub profits_beneficiary_collateral: Pubkey,
 }
 
 impl MercurialVaultDepository {

--- a/programs/uxd/src/state/mercurial_vault_depository.rs
+++ b/programs/uxd/src/state/mercurial_vault_depository.rs
@@ -4,7 +4,7 @@ use fixed::types::I80F48;
 use crate::error::UxdError;
 
 // Total should be 900 bytes
-pub const MERCURIAL_VAULT_RESERVED_SPACE: usize = 677;
+pub const MERCURIAL_VAULT_RESERVED_SPACE: usize = 588;
 pub const MERCURIAL_VAULT_DEPOSITORY_SPACE: usize = 8
     + 1     // bump
     + 1     // version
@@ -26,6 +26,7 @@ pub const MERCURIAL_VAULT_DEPOSITORY_SPACE: usize = 8
     + 1     // minting disabled
     + 16    // profits total collected
     + 8     // last time profits got collected (unix timestamp)
+    + 32     // profits beneficiary
     + MERCURIAL_VAULT_RESERVED_SPACE;
 
 #[account(zero_copy)]
@@ -90,6 +91,9 @@ pub struct MercurialVaultDepository {
 
     // Worth 0 if interests and fees never got collected
     pub last_profits_collection_unix_timestamp: u64,
+
+    // Receiver of the depository's profits
+    pub profits_beneficiary_key: Pubkey,
 }
 
 impl MercurialVaultDepository {

--- a/target/idl/uxd.json
+++ b/target/idl/uxd.json
@@ -1701,7 +1701,7 @@
             "type": "u64"
           },
           {
-            "name": "profitsBeneficiaryKey",
+            "name": "profitsBeneficiaryCollateral",
             "type": "publicKey"
           }
         ]
@@ -1805,7 +1805,7 @@
             }
           },
           {
-            "name": "profitsBeneficiaryKey",
+            "name": "profitsBeneficiaryCollateral",
             "type": {
               "option": "publicKey"
             }
@@ -2014,7 +2014,7 @@
           "index": true
         },
         {
-          "name": "profitsBeneficiaryKey",
+          "name": "profitsBeneficiaryCollateral",
           "type": "publicKey",
           "index": true
         }
@@ -2459,13 +2459,13 @@
     },
     {
       "code": 6034,
-      "name": "InvalidProfitsBeneficiary",
-      "msg": "The Profits beneficiary provided does not match the depository's one."
+      "name": "InvalidProfitsBeneficiaryCollateral",
+      "msg": "The Profits beneficiary collateral provided does not match the depository's one."
     },
     {
       "code": 6035,
-      "name": "ProfitsBeneficiaryNotInitialized",
-      "msg": "The Profits beneficiary provided does not match the depository's one."
+      "name": "UninitializedProfitsBeneficiaryCollateral",
+      "msg": "The Profits beneficiary collateral provided is set to an invalid value."
     },
     {
       "code": 6036,

--- a/target/idl/uxd.json
+++ b/target/idl/uxd.json
@@ -1295,37 +1295,37 @@
       "name": "collectProfitOfMercurialVaultDepository",
       "accounts": [
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["#1"]
-        },
-        {
           "name": "payer",
           "isMut": true,
           "isSigner": true,
-          "docs": ["#2"]
+          "docs": ["#1"]
         },
         {
           "name": "controller",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#3"]
+          "docs": ["#2"]
         },
         {
           "name": "depository",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#4"]
+          "docs": ["#3"]
         },
         {
           "name": "collateralMint",
           "isMut": false,
           "isSigner": false,
+          "docs": ["#4"]
+        },
+        {
+          "name": "profitsBeneficiaryKey",
+          "isMut": false,
+          "isSigner": false,
           "docs": ["#5"]
         },
         {
-          "name": "authorityCollateral",
+          "name": "profitsBeneficiaryCollateral",
           "isMut": true,
           "isSigner": false,
           "docs": ["#6"]
@@ -1705,6 +1705,10 @@
           {
             "name": "lastProfitsCollectionUnixTimestamp",
             "type": "u64"
+          },
+          {
+            "name": "profitsBeneficiaryKey",
+            "type": "publicKey"
           }
         ]
       }
@@ -1804,6 +1808,12 @@
             "name": "mintingDisabled",
             "type": {
               "option": "bool"
+            }
+          },
+          {
+            "name": "profitsBeneficiaryKey",
+            "type": {
+              "option": "publicKey"
             }
           }
         ]
@@ -1987,6 +1997,31 @@
         {
           "name": "mintingDisabled",
           "type": "bool",
+          "index": true
+        }
+      ]
+    },
+    {
+      "name": "SetDepositoryProfitsBeneficiaryKeyEvent",
+      "fields": [
+        {
+          "name": "version",
+          "type": "u8",
+          "index": true
+        },
+        {
+          "name": "controller",
+          "type": "publicKey",
+          "index": true
+        },
+        {
+          "name": "depository",
+          "type": "publicKey",
+          "index": true
+        },
+        {
+          "name": "profitsBeneficiaryKey",
+          "type": "publicKey",
           "index": true
         }
       ]
@@ -2430,76 +2465,81 @@
     },
     {
       "code": 6034,
+      "name": "InvalidProfitsBeneficiary",
+      "msg": "The Profits beneficiary provided does not match the depository's one."
+    },
+    {
+      "code": 6035,
       "name": "InvalidMercurialVault",
       "msg": "The provided mercurial vault does not match the Depository's one."
     },
     {
-      "code": 6035,
+      "code": 6036,
       "name": "InvalidMercurialVaultCollateralTokenSafe",
       "msg": "The provided mercurial vault collateral token safe does not match the mercurial vault one."
     },
     {
-      "code": 6036,
+      "code": 6037,
       "name": "RedeemableIdentityDepositoryAmountUnderManagementCap",
       "msg": "Minting amount would go past the identity depository Redeemable Amount Under Management Cap."
     },
     {
-      "code": 6037,
+      "code": 6038,
       "name": "ProgramAlreadyFrozenOrResumed",
       "msg": "Program is already frozen/resumed."
     },
     {
-      "code": 6038,
+      "code": 6039,
       "name": "ProgramFrozen",
       "msg": "The program is currently in Frozen state."
     },
     {
-      "code": 6039,
+      "code": 6040,
       "name": "InvalidCredixProgramState",
       "msg": "The Credix ProgramState isn't the Depository one."
     },
     {
-      "code": 6040,
+      "code": 6041,
       "name": "InvalidCredixGlobalMarketState",
       "msg": "The Credix GlobalMarketState isn't the Depository one."
     },
     {
-      "code": 6041,
+      "code": 6042,
       "name": "InvalidCredixSigningAuthority",
       "msg": "The Credix SigningAuthority isn't the Depository one."
     },
     {
-      "code": 6042,
+      "code": 6043,
       "name": "InvalidCredixLiquidityCollateral",
       "msg": "The Credix LiquidityCollateral isn't the Depository one."
     },
     {
-      "code": 6043,
+      "code": 6044,
       "name": "InvalidCredixSharesMint",
       "msg": "The Credix SharesMint isn't the Depository one."
     },
     {
-      "code": 6044,
+      "code": 6045,
       "name": "InvalidCredixPass",
       "msg": "The Credix Pass isn't the one owned by the correct depository."
     },
     {
-      "code": 6045,
+      "code": 6046,
       "name": "InvalidCredixPassNoFees",
       "msg": "The Credix Pass doesn't have the fees exemption."
     },
     {
-      "code": 6046,
+      "code": 6047,
       "name": "InvalidCredixMultisigKey",
       "msg": "The Credix Multisig Key isn't the ProgramState one."
     },
     {
-      "code": 6047,
+      "code": 6048,
       "name": "InvalidCredixTreasuryCollateral",
       "msg": "The Credix TreasuryCollateral isn't the GlobalMarketState one."
     },
     {
-      "code": 6048,
+      "code": 6049,
       "name": "Default",
       "msg": "Default - Check the source code for more info."
     }

--- a/target/idl/uxd.json
+++ b/target/idl/uxd.json
@@ -1996,7 +1996,7 @@
       ]
     },
     {
-      "name": "SetDepositoryProfitsBeneficiaryKeyEvent",
+      "name": "SetDepositoryProfitsBeneficiaryCollateralEvent",
       "fields": [
         {
           "name": "version",

--- a/target/idl/uxd.json
+++ b/target/idl/uxd.json
@@ -1319,23 +1319,17 @@
           "docs": ["#4"]
         },
         {
-          "name": "profitsBeneficiaryKey",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["#5"]
-        },
-        {
           "name": "profitsBeneficiaryCollateral",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#6"]
+          "docs": ["#5"]
         },
         {
           "name": "depositoryLpTokenVault",
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#7",
+            "#6",
             "Token account holding the LP tokens minted by depositing collateral on mercurial vault"
           ]
         },
@@ -1343,20 +1337,20 @@
           "name": "mercurialVault",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#8"]
+          "docs": ["#7"]
         },
         {
           "name": "mercurialVaultLpMint",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#9"]
+          "docs": ["#8"]
         },
         {
           "name": "mercurialVaultCollateralTokenSafe",
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#10",
+            "#9",
             "Token account owned by the mercurial vault program. Hold the collateral deposited in the mercurial vault."
           ]
         },
@@ -1364,19 +1358,19 @@
           "name": "mercurialVaultProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#11"]
+          "docs": ["#10"]
         },
         {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#12"]
+          "docs": ["#11"]
         },
         {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#13"]
+          "docs": ["#12"]
         }
       ],
       "args": []
@@ -2470,76 +2464,81 @@
     },
     {
       "code": 6035,
-      "name": "InvalidMercurialVault",
-      "msg": "The provided mercurial vault does not match the Depository's one."
+      "name": "ProfitsBeneficiaryNotInitialized",
+      "msg": "The Profits beneficiary provided does not match the depository's one."
     },
     {
       "code": 6036,
+      "name": "InvalidMercurialVault",
+      "msg": "The profits beneficiary hasn't setup for this depository"
+    },
+    {
+      "code": 6037,
       "name": "InvalidMercurialVaultCollateralTokenSafe",
       "msg": "The provided mercurial vault collateral token safe does not match the mercurial vault one."
     },
     {
-      "code": 6037,
+      "code": 6038,
       "name": "RedeemableIdentityDepositoryAmountUnderManagementCap",
       "msg": "Minting amount would go past the identity depository Redeemable Amount Under Management Cap."
     },
     {
-      "code": 6038,
+      "code": 6039,
       "name": "ProgramAlreadyFrozenOrResumed",
       "msg": "Program is already frozen/resumed."
     },
     {
-      "code": 6039,
+      "code": 6040,
       "name": "ProgramFrozen",
       "msg": "The program is currently in Frozen state."
     },
     {
-      "code": 6040,
+      "code": 6041,
       "name": "InvalidCredixProgramState",
       "msg": "The Credix ProgramState isn't the Depository one."
     },
     {
-      "code": 6041,
+      "code": 6042,
       "name": "InvalidCredixGlobalMarketState",
       "msg": "The Credix GlobalMarketState isn't the Depository one."
     },
     {
-      "code": 6042,
+      "code": 6043,
       "name": "InvalidCredixSigningAuthority",
       "msg": "The Credix SigningAuthority isn't the Depository one."
     },
     {
-      "code": 6043,
+      "code": 6044,
       "name": "InvalidCredixLiquidityCollateral",
       "msg": "The Credix LiquidityCollateral isn't the Depository one."
     },
     {
-      "code": 6044,
+      "code": 6045,
       "name": "InvalidCredixSharesMint",
       "msg": "The Credix SharesMint isn't the Depository one."
     },
     {
-      "code": 6045,
+      "code": 6046,
       "name": "InvalidCredixPass",
       "msg": "The Credix Pass isn't the one owned by the correct depository."
     },
     {
-      "code": 6046,
+      "code": 6047,
       "name": "InvalidCredixPassNoFees",
       "msg": "The Credix Pass doesn't have the fees exemption."
     },
     {
-      "code": 6047,
+      "code": 6048,
       "name": "InvalidCredixMultisigKey",
       "msg": "The Credix Multisig Key isn't the ProgramState one."
     },
     {
-      "code": 6048,
+      "code": 6049,
       "name": "InvalidCredixTreasuryCollateral",
       "msg": "The Credix TreasuryCollateral isn't the GlobalMarketState one."
     },
     {
-      "code": 6049,
+      "code": 6050,
       "name": "Default",
       "msg": "Default - Check the source code for more info."
     }

--- a/target/types/uxd.ts
+++ b/target/types/uxd.ts
@@ -1295,37 +1295,37 @@ export type Uxd = {
       name: 'collectProfitOfMercurialVaultDepository'
       accounts: [
         {
-          name: 'authority'
-          isMut: false
-          isSigner: true
-          docs: ['#1']
-        },
-        {
           name: 'payer'
           isMut: true
           isSigner: true
-          docs: ['#2']
+          docs: ['#1']
         },
         {
           name: 'controller'
           isMut: true
           isSigner: false
-          docs: ['#3']
+          docs: ['#2']
         },
         {
           name: 'depository'
           isMut: true
           isSigner: false
-          docs: ['#4']
+          docs: ['#3']
         },
         {
           name: 'collateralMint'
           isMut: false
           isSigner: false
+          docs: ['#4']
+        },
+        {
+          name: 'profitsBeneficiaryKey'
+          isMut: false
+          isSigner: false
           docs: ['#5']
         },
         {
-          name: 'authorityCollateral'
+          name: 'profitsBeneficiaryCollateral'
           isMut: true
           isSigner: false
           docs: ['#6']
@@ -1705,6 +1705,10 @@ export type Uxd = {
           {
             name: 'lastProfitsCollectionUnixTimestamp'
             type: 'u64'
+          },
+          {
+            name: 'profitsBeneficiaryKey'
+            type: 'publicKey'
           }
         ]
       }
@@ -1804,6 +1808,12 @@ export type Uxd = {
             name: 'mintingDisabled'
             type: {
               option: 'bool'
+            }
+          },
+          {
+            name: 'profitsBeneficiaryKey'
+            type: {
+              option: 'publicKey'
             }
           }
         ]
@@ -1987,6 +1997,31 @@ export type Uxd = {
         {
           name: 'mintingDisabled'
           type: 'bool'
+          index: true
+        }
+      ]
+    },
+    {
+      name: 'SetDepositoryProfitsBeneficiaryKeyEvent'
+      fields: [
+        {
+          name: 'version'
+          type: 'u8'
+          index: true
+        },
+        {
+          name: 'controller'
+          type: 'publicKey'
+          index: true
+        },
+        {
+          name: 'depository'
+          type: 'publicKey'
+          index: true
+        },
+        {
+          name: 'profitsBeneficiaryKey'
+          type: 'publicKey'
           index: true
         }
       ]
@@ -2430,76 +2465,81 @@ export type Uxd = {
     },
     {
       code: 6034
+      name: 'InvalidProfitsBeneficiary'
+      msg: "The Profits beneficiary provided does not match the depository's one."
+    },
+    {
+      code: 6035
       name: 'InvalidMercurialVault'
       msg: "The provided mercurial vault does not match the Depository's one."
     },
     {
-      code: 6035
+      code: 6036
       name: 'InvalidMercurialVaultCollateralTokenSafe'
       msg: 'The provided mercurial vault collateral token safe does not match the mercurial vault one.'
     },
     {
-      code: 6036
+      code: 6037
       name: 'RedeemableIdentityDepositoryAmountUnderManagementCap'
       msg: 'Minting amount would go past the identity depository Redeemable Amount Under Management Cap.'
     },
     {
-      code: 6037
+      code: 6038
       name: 'ProgramAlreadyFrozenOrResumed'
       msg: 'Program is already frozen/resumed.'
     },
     {
-      code: 6038
+      code: 6039
       name: 'ProgramFrozen'
       msg: 'The program is currently in Frozen state.'
     },
     {
-      code: 6039
+      code: 6040
       name: 'InvalidCredixProgramState'
       msg: "The Credix ProgramState isn't the Depository one."
     },
     {
-      code: 6040
+      code: 6041
       name: 'InvalidCredixGlobalMarketState'
       msg: "The Credix GlobalMarketState isn't the Depository one."
     },
     {
-      code: 6041
+      code: 6042
       name: 'InvalidCredixSigningAuthority'
       msg: "The Credix SigningAuthority isn't the Depository one."
     },
     {
-      code: 6042
+      code: 6043
       name: 'InvalidCredixLiquidityCollateral'
       msg: "The Credix LiquidityCollateral isn't the Depository one."
     },
     {
-      code: 6043
+      code: 6044
       name: 'InvalidCredixSharesMint'
       msg: "The Credix SharesMint isn't the Depository one."
     },
     {
-      code: 6044
+      code: 6045
       name: 'InvalidCredixPass'
       msg: "The Credix Pass isn't the one owned by the correct depository."
     },
     {
-      code: 6045
+      code: 6046
       name: 'InvalidCredixPassNoFees'
       msg: "The Credix Pass doesn't have the fees exemption."
     },
     {
-      code: 6046
+      code: 6047
       name: 'InvalidCredixMultisigKey'
       msg: "The Credix Multisig Key isn't the ProgramState one."
     },
     {
-      code: 6047
+      code: 6048
       name: 'InvalidCredixTreasuryCollateral'
       msg: "The Credix TreasuryCollateral isn't the GlobalMarketState one."
     },
     {
-      code: 6048
+      code: 6049
       name: 'Default'
       msg: 'Default - Check the source code for more info.'
     }
@@ -3803,37 +3843,37 @@ export const IDL: Uxd = {
       name: 'collectProfitOfMercurialVaultDepository',
       accounts: [
         {
-          name: 'authority',
-          isMut: false,
-          isSigner: true,
-          docs: ['#1']
-        },
-        {
           name: 'payer',
           isMut: true,
           isSigner: true,
-          docs: ['#2']
+          docs: ['#1']
         },
         {
           name: 'controller',
           isMut: true,
           isSigner: false,
-          docs: ['#3']
+          docs: ['#2']
         },
         {
           name: 'depository',
           isMut: true,
           isSigner: false,
-          docs: ['#4']
+          docs: ['#3']
         },
         {
           name: 'collateralMint',
           isMut: false,
           isSigner: false,
+          docs: ['#4']
+        },
+        {
+          name: 'profitsBeneficiaryKey',
+          isMut: false,
+          isSigner: false,
           docs: ['#5']
         },
         {
-          name: 'authorityCollateral',
+          name: 'profitsBeneficiaryCollateral',
           isMut: true,
           isSigner: false,
           docs: ['#6']
@@ -4213,6 +4253,10 @@ export const IDL: Uxd = {
           {
             name: 'lastProfitsCollectionUnixTimestamp',
             type: 'u64'
+          },
+          {
+            name: 'profitsBeneficiaryKey',
+            type: 'publicKey'
           }
         ]
       }
@@ -4312,6 +4356,12 @@ export const IDL: Uxd = {
             name: 'mintingDisabled',
             type: {
               option: 'bool'
+            }
+          },
+          {
+            name: 'profitsBeneficiaryKey',
+            type: {
+              option: 'publicKey'
             }
           }
         ]
@@ -4495,6 +4545,31 @@ export const IDL: Uxd = {
         {
           name: 'mintingDisabled',
           type: 'bool',
+          index: true
+        }
+      ]
+    },
+    {
+      name: 'SetDepositoryProfitsBeneficiaryKeyEvent',
+      fields: [
+        {
+          name: 'version',
+          type: 'u8',
+          index: true
+        },
+        {
+          name: 'controller',
+          type: 'publicKey',
+          index: true
+        },
+        {
+          name: 'depository',
+          type: 'publicKey',
+          index: true
+        },
+        {
+          name: 'profitsBeneficiaryKey',
+          type: 'publicKey',
           index: true
         }
       ]
@@ -4938,76 +5013,81 @@ export const IDL: Uxd = {
     },
     {
       code: 6034,
+      name: 'InvalidProfitsBeneficiary',
+      msg: "The Profits beneficiary provided does not match the depository's one."
+    },
+    {
+      code: 6035,
       name: 'InvalidMercurialVault',
       msg: "The provided mercurial vault does not match the Depository's one."
     },
     {
-      code: 6035,
+      code: 6036,
       name: 'InvalidMercurialVaultCollateralTokenSafe',
       msg: 'The provided mercurial vault collateral token safe does not match the mercurial vault one.'
     },
     {
-      code: 6036,
+      code: 6037,
       name: 'RedeemableIdentityDepositoryAmountUnderManagementCap',
       msg: 'Minting amount would go past the identity depository Redeemable Amount Under Management Cap.'
     },
     {
-      code: 6037,
+      code: 6038,
       name: 'ProgramAlreadyFrozenOrResumed',
       msg: 'Program is already frozen/resumed.'
     },
     {
-      code: 6038,
+      code: 6039,
       name: 'ProgramFrozen',
       msg: 'The program is currently in Frozen state.'
     },
     {
-      code: 6039,
+      code: 6040,
       name: 'InvalidCredixProgramState',
       msg: "The Credix ProgramState isn't the Depository one."
     },
     {
-      code: 6040,
+      code: 6041,
       name: 'InvalidCredixGlobalMarketState',
       msg: "The Credix GlobalMarketState isn't the Depository one."
     },
     {
-      code: 6041,
+      code: 6042,
       name: 'InvalidCredixSigningAuthority',
       msg: "The Credix SigningAuthority isn't the Depository one."
     },
     {
-      code: 6042,
+      code: 6043,
       name: 'InvalidCredixLiquidityCollateral',
       msg: "The Credix LiquidityCollateral isn't the Depository one."
     },
     {
-      code: 6043,
+      code: 6044,
       name: 'InvalidCredixSharesMint',
       msg: "The Credix SharesMint isn't the Depository one."
     },
     {
-      code: 6044,
+      code: 6045,
       name: 'InvalidCredixPass',
       msg: "The Credix Pass isn't the one owned by the correct depository."
     },
     {
-      code: 6045,
+      code: 6046,
       name: 'InvalidCredixPassNoFees',
       msg: "The Credix Pass doesn't have the fees exemption."
     },
     {
-      code: 6046,
+      code: 6047,
       name: 'InvalidCredixMultisigKey',
       msg: "The Credix Multisig Key isn't the ProgramState one."
     },
     {
-      code: 6047,
+      code: 6048,
       name: 'InvalidCredixTreasuryCollateral',
       msg: "The Credix TreasuryCollateral isn't the GlobalMarketState one."
     },
     {
-      code: 6048,
+      code: 6049,
       name: 'Default',
       msg: 'Default - Check the source code for more info.'
     }

--- a/target/types/uxd.ts
+++ b/target/types/uxd.ts
@@ -1701,7 +1701,7 @@ export type Uxd = {
             type: 'u64'
           },
           {
-            name: 'profitsBeneficiaryKey'
+            name: 'profitsBeneficiaryCollateral'
             type: 'publicKey'
           }
         ]
@@ -1805,7 +1805,7 @@ export type Uxd = {
             }
           },
           {
-            name: 'profitsBeneficiaryKey'
+            name: 'profitsBeneficiaryCollateral'
             type: {
               option: 'publicKey'
             }
@@ -2014,7 +2014,7 @@ export type Uxd = {
           index: true
         },
         {
-          name: 'profitsBeneficiaryKey'
+          name: 'profitsBeneficiaryCollateral'
           type: 'publicKey'
           index: true
         }
@@ -2459,13 +2459,13 @@ export type Uxd = {
     },
     {
       code: 6034
-      name: 'InvalidProfitsBeneficiary'
-      msg: "The Profits beneficiary provided does not match the depository's one."
+      name: 'InvalidProfitsBeneficiaryCollateral'
+      msg: "The Profits beneficiary collateral provided does not match the depository's one."
     },
     {
       code: 6035
-      name: 'ProfitsBeneficiaryNotInitialized'
-      msg: "The Profits beneficiary provided does not match the depository's one."
+      name: 'UninitializedProfitsBeneficiaryCollateral'
+      msg: 'The Profits beneficiary collateral provided is set to an invalid value.'
     },
     {
       code: 6036
@@ -4248,7 +4248,7 @@ export const IDL: Uxd = {
             type: 'u64'
           },
           {
-            name: 'profitsBeneficiaryKey',
+            name: 'profitsBeneficiaryCollateral',
             type: 'publicKey'
           }
         ]
@@ -4352,7 +4352,7 @@ export const IDL: Uxd = {
             }
           },
           {
-            name: 'profitsBeneficiaryKey',
+            name: 'profitsBeneficiaryCollateral',
             type: {
               option: 'publicKey'
             }
@@ -4561,7 +4561,7 @@ export const IDL: Uxd = {
           index: true
         },
         {
-          name: 'profitsBeneficiaryKey',
+          name: 'profitsBeneficiaryCollateral',
           type: 'publicKey',
           index: true
         }
@@ -5006,13 +5006,13 @@ export const IDL: Uxd = {
     },
     {
       code: 6034,
-      name: 'InvalidProfitsBeneficiary',
-      msg: "The Profits beneficiary provided does not match the depository's one."
+      name: 'InvalidProfitsBeneficiaryCollateral',
+      msg: "The Profits beneficiary collateral provided does not match the depository's one."
     },
     {
       code: 6035,
-      name: 'ProfitsBeneficiaryNotInitialized',
-      msg: "The Profits beneficiary provided does not match the depository's one."
+      name: 'UninitializedProfitsBeneficiaryCollateral',
+      msg: 'The Profits beneficiary collateral provided is set to an invalid value.'
     },
     {
       code: 6036,

--- a/target/types/uxd.ts
+++ b/target/types/uxd.ts
@@ -1319,23 +1319,17 @@ export type Uxd = {
           docs: ['#4']
         },
         {
-          name: 'profitsBeneficiaryKey'
-          isMut: false
-          isSigner: false
-          docs: ['#5']
-        },
-        {
           name: 'profitsBeneficiaryCollateral'
           isMut: true
           isSigner: false
-          docs: ['#6']
+          docs: ['#5']
         },
         {
           name: 'depositoryLpTokenVault'
           isMut: true
           isSigner: false
           docs: [
-            '#7',
+            '#6',
             'Token account holding the LP tokens minted by depositing collateral on mercurial vault'
           ]
         },
@@ -1343,20 +1337,20 @@ export type Uxd = {
           name: 'mercurialVault'
           isMut: true
           isSigner: false
-          docs: ['#8']
+          docs: ['#7']
         },
         {
           name: 'mercurialVaultLpMint'
           isMut: true
           isSigner: false
-          docs: ['#9']
+          docs: ['#8']
         },
         {
           name: 'mercurialVaultCollateralTokenSafe'
           isMut: true
           isSigner: false
           docs: [
-            '#10',
+            '#9',
             'Token account owned by the mercurial vault program. Hold the collateral deposited in the mercurial vault.'
           ]
         },
@@ -1364,19 +1358,19 @@ export type Uxd = {
           name: 'mercurialVaultProgram'
           isMut: false
           isSigner: false
-          docs: ['#11']
+          docs: ['#10']
         },
         {
           name: 'systemProgram'
           isMut: false
           isSigner: false
-          docs: ['#12']
+          docs: ['#11']
         },
         {
           name: 'tokenProgram'
           isMut: false
           isSigner: false
-          docs: ['#13']
+          docs: ['#12']
         }
       ]
       args: []
@@ -2470,76 +2464,81 @@ export type Uxd = {
     },
     {
       code: 6035
-      name: 'InvalidMercurialVault'
-      msg: "The provided mercurial vault does not match the Depository's one."
+      name: 'ProfitsBeneficiaryNotInitialized'
+      msg: "The Profits beneficiary provided does not match the depository's one."
     },
     {
       code: 6036
+      name: 'InvalidMercurialVault'
+      msg: "The profits beneficiary hasn't setup for this depository"
+    },
+    {
+      code: 6037
       name: 'InvalidMercurialVaultCollateralTokenSafe'
       msg: 'The provided mercurial vault collateral token safe does not match the mercurial vault one.'
     },
     {
-      code: 6037
+      code: 6038
       name: 'RedeemableIdentityDepositoryAmountUnderManagementCap'
       msg: 'Minting amount would go past the identity depository Redeemable Amount Under Management Cap.'
     },
     {
-      code: 6038
+      code: 6039
       name: 'ProgramAlreadyFrozenOrResumed'
       msg: 'Program is already frozen/resumed.'
     },
     {
-      code: 6039
+      code: 6040
       name: 'ProgramFrozen'
       msg: 'The program is currently in Frozen state.'
     },
     {
-      code: 6040
+      code: 6041
       name: 'InvalidCredixProgramState'
       msg: "The Credix ProgramState isn't the Depository one."
     },
     {
-      code: 6041
+      code: 6042
       name: 'InvalidCredixGlobalMarketState'
       msg: "The Credix GlobalMarketState isn't the Depository one."
     },
     {
-      code: 6042
+      code: 6043
       name: 'InvalidCredixSigningAuthority'
       msg: "The Credix SigningAuthority isn't the Depository one."
     },
     {
-      code: 6043
+      code: 6044
       name: 'InvalidCredixLiquidityCollateral'
       msg: "The Credix LiquidityCollateral isn't the Depository one."
     },
     {
-      code: 6044
+      code: 6045
       name: 'InvalidCredixSharesMint'
       msg: "The Credix SharesMint isn't the Depository one."
     },
     {
-      code: 6045
+      code: 6046
       name: 'InvalidCredixPass'
       msg: "The Credix Pass isn't the one owned by the correct depository."
     },
     {
-      code: 6046
+      code: 6047
       name: 'InvalidCredixPassNoFees'
       msg: "The Credix Pass doesn't have the fees exemption."
     },
     {
-      code: 6047
+      code: 6048
       name: 'InvalidCredixMultisigKey'
       msg: "The Credix Multisig Key isn't the ProgramState one."
     },
     {
-      code: 6048
+      code: 6049
       name: 'InvalidCredixTreasuryCollateral'
       msg: "The Credix TreasuryCollateral isn't the GlobalMarketState one."
     },
     {
-      code: 6049
+      code: 6050
       name: 'Default'
       msg: 'Default - Check the source code for more info.'
     }
@@ -3867,23 +3866,17 @@ export const IDL: Uxd = {
           docs: ['#4']
         },
         {
-          name: 'profitsBeneficiaryKey',
-          isMut: false,
-          isSigner: false,
-          docs: ['#5']
-        },
-        {
           name: 'profitsBeneficiaryCollateral',
           isMut: true,
           isSigner: false,
-          docs: ['#6']
+          docs: ['#5']
         },
         {
           name: 'depositoryLpTokenVault',
           isMut: true,
           isSigner: false,
           docs: [
-            '#7',
+            '#6',
             'Token account holding the LP tokens minted by depositing collateral on mercurial vault'
           ]
         },
@@ -3891,20 +3884,20 @@ export const IDL: Uxd = {
           name: 'mercurialVault',
           isMut: true,
           isSigner: false,
-          docs: ['#8']
+          docs: ['#7']
         },
         {
           name: 'mercurialVaultLpMint',
           isMut: true,
           isSigner: false,
-          docs: ['#9']
+          docs: ['#8']
         },
         {
           name: 'mercurialVaultCollateralTokenSafe',
           isMut: true,
           isSigner: false,
           docs: [
-            '#10',
+            '#9',
             'Token account owned by the mercurial vault program. Hold the collateral deposited in the mercurial vault.'
           ]
         },
@@ -3912,19 +3905,19 @@ export const IDL: Uxd = {
           name: 'mercurialVaultProgram',
           isMut: false,
           isSigner: false,
-          docs: ['#11']
+          docs: ['#10']
         },
         {
           name: 'systemProgram',
           isMut: false,
           isSigner: false,
-          docs: ['#12']
+          docs: ['#11']
         },
         {
           name: 'tokenProgram',
           isMut: false,
           isSigner: false,
-          docs: ['#13']
+          docs: ['#12']
         }
       ],
       args: []
@@ -5018,76 +5011,81 @@ export const IDL: Uxd = {
     },
     {
       code: 6035,
-      name: 'InvalidMercurialVault',
-      msg: "The provided mercurial vault does not match the Depository's one."
+      name: 'ProfitsBeneficiaryNotInitialized',
+      msg: "The Profits beneficiary provided does not match the depository's one."
     },
     {
       code: 6036,
+      name: 'InvalidMercurialVault',
+      msg: "The profits beneficiary hasn't setup for this depository"
+    },
+    {
+      code: 6037,
       name: 'InvalidMercurialVaultCollateralTokenSafe',
       msg: 'The provided mercurial vault collateral token safe does not match the mercurial vault one.'
     },
     {
-      code: 6037,
+      code: 6038,
       name: 'RedeemableIdentityDepositoryAmountUnderManagementCap',
       msg: 'Minting amount would go past the identity depository Redeemable Amount Under Management Cap.'
     },
     {
-      code: 6038,
+      code: 6039,
       name: 'ProgramAlreadyFrozenOrResumed',
       msg: 'Program is already frozen/resumed.'
     },
     {
-      code: 6039,
+      code: 6040,
       name: 'ProgramFrozen',
       msg: 'The program is currently in Frozen state.'
     },
     {
-      code: 6040,
+      code: 6041,
       name: 'InvalidCredixProgramState',
       msg: "The Credix ProgramState isn't the Depository one."
     },
     {
-      code: 6041,
+      code: 6042,
       name: 'InvalidCredixGlobalMarketState',
       msg: "The Credix GlobalMarketState isn't the Depository one."
     },
     {
-      code: 6042,
+      code: 6043,
       name: 'InvalidCredixSigningAuthority',
       msg: "The Credix SigningAuthority isn't the Depository one."
     },
     {
-      code: 6043,
+      code: 6044,
       name: 'InvalidCredixLiquidityCollateral',
       msg: "The Credix LiquidityCollateral isn't the Depository one."
     },
     {
-      code: 6044,
+      code: 6045,
       name: 'InvalidCredixSharesMint',
       msg: "The Credix SharesMint isn't the Depository one."
     },
     {
-      code: 6045,
+      code: 6046,
       name: 'InvalidCredixPass',
       msg: "The Credix Pass isn't the one owned by the correct depository."
     },
     {
-      code: 6046,
+      code: 6047,
       name: 'InvalidCredixPassNoFees',
       msg: "The Credix Pass doesn't have the fees exemption."
     },
     {
-      code: 6047,
+      code: 6048,
       name: 'InvalidCredixMultisigKey',
       msg: "The Credix Multisig Key isn't the ProgramState one."
     },
     {
-      code: 6048,
+      code: 6049,
       name: 'InvalidCredixTreasuryCollateral',
       msg: "The Credix TreasuryCollateral isn't the GlobalMarketState one."
     },
     {
-      code: 6049,
+      code: 6050,
       name: 'Default',
       msg: 'Default - Check the source code for more info.'
     }

--- a/target/types/uxd.ts
+++ b/target/types/uxd.ts
@@ -1996,7 +1996,7 @@ export type Uxd = {
       ]
     },
     {
-      name: 'SetDepositoryProfitsBeneficiaryKeyEvent'
+      name: 'SetDepositoryProfitsBeneficiaryCollateralEvent'
       fields: [
         {
           name: 'version'
@@ -4543,7 +4543,7 @@ export const IDL: Uxd = {
       ]
     },
     {
-      name: 'SetDepositoryProfitsBeneficiaryKeyEvent',
+      name: 'SetDepositoryProfitsBeneficiaryCollateralEvent',
       fields: [
         {
           name: 'version',

--- a/tests/api.ts
+++ b/tests/api.ts
@@ -213,6 +213,7 @@ export async function editMercurialVaultDepository({
     mintingFeeInBps?: number;
     redeemingFeeInBps?: number;
     mintingDisabled?: boolean;
+    profitsBeneficiaryCollateral?: PublicKey;
   };
 }): Promise<string> {
   const editMercurialVaultDepositoryIx =
@@ -593,38 +594,24 @@ export async function collectProfitOfMercurialVaultDepository({
   payer,
   controller,
   depository,
-  profitsBeneficiaryKey,
+  profitsBeneficiaryCollateral,
 }: {
   payer: Signer;
   controller: Controller;
   depository: MercurialVaultDepository;
-  profitsBeneficiaryKey: PublicKey;
+  profitsBeneficiaryCollateral: PublicKey;
 }): Promise<string> {
   const collectInterestsAndFeesFromMercurialVaultDepositoryIx =
     uxdClient.createCollectProfitOfMercurialVaultDepositoryInstruction(
       controller,
       depository,
-      profitsBeneficiaryKey,
+      profitsBeneficiaryCollateral,
       TXN_OPTS,
       payer.publicKey
     );
+
   let signers = [];
   let tx = new Transaction();
-
-  const [profitsBeneficiaryCollateralAta] = findATAAddrSync(
-    profitsBeneficiaryKey,
-    depository.collateralMint.mint
-  );
-  if (
-    !(await getConnection().getAccountInfo(profitsBeneficiaryCollateralAta))
-  ) {
-    const createProfitsBeneficiaryCollateralAtaIx = createAssocTokenIx(
-      profitsBeneficiaryKey,
-      profitsBeneficiaryCollateralAta,
-      controller.redeemableMintPda
-    );
-    tx.add(createProfitsBeneficiaryCollateralAtaIx);
-  }
 
   tx.add(collectInterestsAndFeesFromMercurialVaultDepositoryIx);
   signers.push(payer);

--- a/tests/cases/collectProfitOfMercurialVaultDepositoryTest.ts
+++ b/tests/cases/collectProfitOfMercurialVaultDepositoryTest.ts
@@ -24,22 +24,16 @@ export const collectProfitOfMercurialVaultDepositoryTest = async function ({
 
   try {
     // GIVEN
-    const profitsBeneficiaryKey = await depository.getProfitsBeneficiaryKey(
-      getConnection(),
-      TXN_OPTS
-    );
-
-    const [profitsBeneficiaryCollateralAta] = findATAAddrSync(
-      profitsBeneficiaryKey,
-      depository.collateralMint.mint
-    );
+    const profitsBeneficiaryCollateral = (
+      await depository.getOnchainAccount(getConnection(), TXN_OPTS)
+    ).profitsBeneficiaryCollateral;
 
     const [
       profitsBeneficiaryCollateralBalance_pre,
       onChainDepository_pre,
       onChainController_pre,
     ] = await Promise.all([
-      getBalance(profitsBeneficiaryCollateralAta),
+      getBalance(profitsBeneficiaryCollateral),
       depository.getOnchainAccount(getConnection(), TXN_OPTS),
       controller.getOnchainAccount(getConnection(), TXN_OPTS),
     ]);
@@ -59,7 +53,7 @@ export const collectProfitOfMercurialVaultDepositoryTest = async function ({
       payer: payer,
       controller,
       depository,
-      profitsBeneficiaryKey,
+      profitsBeneficiaryCollateral,
     });
     console.log(
       `🔗 'https://explorer.solana.com/tx/${txId}?cluster=${CLUSTER}'`
@@ -71,7 +65,7 @@ export const collectProfitOfMercurialVaultDepositoryTest = async function ({
       onChainDepository_post,
       onChainController_post,
     ] = await Promise.all([
-      getBalance(profitsBeneficiaryCollateralAta),
+      getBalance(profitsBeneficiaryCollateral),
       depository.getOnchainAccount(getConnection(), TXN_OPTS),
       controller.getOnchainAccount(getConnection(), TXN_OPTS),
     ]);

--- a/tests/cases/collectProfitOfMercurialVaultDepositoryTest.ts
+++ b/tests/cases/collectProfitOfMercurialVaultDepositoryTest.ts
@@ -1,4 +1,4 @@
-import { Signer } from '@solana/web3.js';
+import { PublicKey, Signer } from '@solana/web3.js';
 import {
   findATAAddrSync,
   Controller,
@@ -12,31 +12,34 @@ import { CLUSTER } from '../constants';
 import { getBalance } from '../utils';
 
 export const collectProfitOfMercurialVaultDepositoryTest = async function ({
-  authority,
   controller,
   depository,
   payer,
 }: {
-  authority: Signer;
   controller: Controller;
   depository: MercurialVaultDepository;
-  payer?: Signer;
+  payer: Signer;
 }): Promise<number> {
   console.group('🧭 collectProfitOfMercurialVaultDepositoryTest');
 
   try {
     // GIVEN
-    const [profitsRedeemAuthorityCollateralATA] = findATAAddrSync(
-      authority.publicKey,
+    const profitsBeneficiaryKey = await depository.getProfitsBeneficiaryKey(
+      getConnection(),
+      TXN_OPTS
+    );
+
+    const [profitsBeneficiaryCollateralAta] = findATAAddrSync(
+      profitsBeneficiaryKey,
       depository.collateralMint.mint
     );
 
     const [
-      profitsRedeemAuthorityCollateralBalance_pre,
+      profitsBeneficiaryCollateralBalance_pre,
       onChainDepository_pre,
       onChainController_pre,
     ] = await Promise.all([
-      getBalance(profitsRedeemAuthorityCollateralATA),
+      getBalance(profitsBeneficiaryCollateralAta),
       depository.getOnchainAccount(getConnection(), TXN_OPTS),
       controller.getOnchainAccount(getConnection(), TXN_OPTS),
     ]);
@@ -53,10 +56,10 @@ export const collectProfitOfMercurialVaultDepositoryTest = async function ({
     // WHEN
     // Simulates user experience from the front end
     const txId = await collectProfitOfMercurialVaultDepository({
-      authority,
-      payer: payer ?? authority,
+      payer: payer,
       controller,
       depository,
+      profitsBeneficiaryKey,
     });
     console.log(
       `🔗 'https://explorer.solana.com/tx/${txId}?cluster=${CLUSTER}'`
@@ -64,11 +67,11 @@ export const collectProfitOfMercurialVaultDepositoryTest = async function ({
 
     // THEN
     const [
-      profitsRedeemAuthorityCollateralBalance_post,
+      profitsBeneficiaryCollateralBalance_post,
       onChainDepository_post,
       onChainController_post,
     ] = await Promise.all([
-      getBalance(profitsRedeemAuthorityCollateralATA),
+      getBalance(profitsBeneficiaryCollateralAta),
       depository.getOnchainAccount(getConnection(), TXN_OPTS),
       controller.getOnchainAccount(getConnection(), TXN_OPTS),
     ]);
@@ -76,8 +79,8 @@ export const collectProfitOfMercurialVaultDepositoryTest = async function ({
     // Use toFixed to avoid +0.010000000000000009 != than +0.01
     const collateralDelta = Number(
       (
-        profitsRedeemAuthorityCollateralBalance_post -
-        profitsRedeemAuthorityCollateralBalance_pre
+        profitsBeneficiaryCollateralBalance_post -
+        profitsBeneficiaryCollateralBalance_pre
       ).toFixed(depository.collateralMint.decimals)
     );
 

--- a/tests/cases/editMercurialVaultDepositoryTest.ts
+++ b/tests/cases/editMercurialVaultDepositoryTest.ts
@@ -1,4 +1,4 @@
-import { Signer } from '@solana/web3.js';
+import { PublicKey, Signer } from '@solana/web3.js';
 import {
   Controller,
   MercurialVaultDepository,
@@ -23,6 +23,7 @@ export const editMercurialVaultDepositoryTest = async function ({
     mintingFeeInBps?: number;
     redeemingFeeInBps?: number;
     mintingDisabled?: boolean;
+    profitsBeneficiaryKey?: PublicKey;
   };
 }) {
   const connection = getConnection();
@@ -41,6 +42,7 @@ export const editMercurialVaultDepositoryTest = async function ({
       mintingFeeInBps,
       redeemingFeeInBps,
       mintingDisabled,
+      profitsBeneficiaryKey,
     } = depositoryOnchainAccount;
 
     // WHEN
@@ -65,6 +67,7 @@ export const editMercurialVaultDepositoryTest = async function ({
       mintingFeeInBps: mintingFeeInBps_post,
       redeemingFeeInBps: redeemingFeeInBps_post,
       mintingDisabled: mintingDisabled_post,
+      profitsBeneficiaryKey: profitsBeneficiaryKey_post,
     } = depositoryOnchainAccount_post;
 
     if (uiFields.redeemableAmountUnderManagementCap) {
@@ -117,6 +120,18 @@ export const editMercurialVaultDepositoryTest = async function ({
         mintingDisabled,
         'now is',
         mintingDisabled_post
+      );
+    }
+    if (typeof uiFields.profitsBeneficiaryKey !== 'undefined') {
+      expect(profitsBeneficiaryKey_post).equals(
+        uiFields.profitsBeneficiaryKey,
+        'The profits beneficiary key state has not changed.'
+      );
+      console.log(
+        `🧾 Previous profits beneficiary key state was`,
+        profitsBeneficiaryKey,
+        'now is',
+        profitsBeneficiaryKey_post
       );
     }
 

--- a/tests/cases/editMercurialVaultDepositoryTest.ts
+++ b/tests/cases/editMercurialVaultDepositoryTest.ts
@@ -23,7 +23,7 @@ export const editMercurialVaultDepositoryTest = async function ({
     mintingFeeInBps?: number;
     redeemingFeeInBps?: number;
     mintingDisabled?: boolean;
-    profitsBeneficiaryKey?: PublicKey;
+    profitsBeneficiaryCollateral?: PublicKey;
   };
 }) {
   const connection = getConnection();
@@ -42,7 +42,7 @@ export const editMercurialVaultDepositoryTest = async function ({
       mintingFeeInBps,
       redeemingFeeInBps,
       mintingDisabled,
-      profitsBeneficiaryKey,
+      profitsBeneficiaryCollateral,
     } = depositoryOnchainAccount;
 
     // WHEN
@@ -67,7 +67,7 @@ export const editMercurialVaultDepositoryTest = async function ({
       mintingFeeInBps: mintingFeeInBps_post,
       redeemingFeeInBps: redeemingFeeInBps_post,
       mintingDisabled: mintingDisabled_post,
-      profitsBeneficiaryKey: profitsBeneficiaryKey_post,
+      profitsBeneficiaryCollateral: profitsBeneficiaryCollateral_post,
     } = depositoryOnchainAccount_post;
 
     if (uiFields.redeemableAmountUnderManagementCap) {
@@ -122,16 +122,16 @@ export const editMercurialVaultDepositoryTest = async function ({
         mintingDisabled_post
       );
     }
-    if (typeof uiFields.profitsBeneficiaryKey !== 'undefined') {
-      expect(profitsBeneficiaryKey_post).equals(
-        uiFields.profitsBeneficiaryKey,
+    if (typeof uiFields.profitsBeneficiaryCollateral !== 'undefined') {
+      expect(profitsBeneficiaryCollateral_post).equals(
+        uiFields.profitsBeneficiaryCollateral,
         'The profits beneficiary key state has not changed.'
       );
       console.log(
         `🧾 Previous profits beneficiary key state was`,
-        profitsBeneficiaryKey,
+        profitsBeneficiaryCollateral,
         'now is',
-        profitsBeneficiaryKey_post
+        profitsBeneficiaryCollateral_post
       );
     }
 

--- a/tests/suite/editMercurialVaultDepositorySuite.ts
+++ b/tests/suite/editMercurialVaultDepositorySuite.ts
@@ -1,4 +1,4 @@
-import { Signer } from '@solana/web3.js';
+import { PublicKey, Signer } from '@solana/web3.js';
 import {
   Controller,
   MercurialVaultDepository,
@@ -107,6 +107,21 @@ export const editMercurialVaultDepositorySuite = async function ({
       });
     });
 
+    it(`Edit profitsBeneficiaryKey alone should work`, async function () {
+      const profitsBeneficiaryKey = new PublicKey('42');
+
+      console.log('[🧾 profitsBeneficiaryKey', profitsBeneficiaryKey, ']');
+
+      await editMercurialVaultDepositoryTest({
+        authority,
+        controller,
+        depository,
+        uiFields: {
+          profitsBeneficiaryKey,
+        },
+      });
+    });
+
     // Restore initial depository values there
     it('Edit mintingFeeInBps/redeemingFeeInBps/redeemableAmountUnderManagementCap should work', async function () {
       const {
@@ -114,6 +129,7 @@ export const editMercurialVaultDepositorySuite = async function ({
         redeemingFeeInBps,
         redeemableAmountUnderManagementCap,
         mintingDisabled,
+        profitsBeneficiaryKey,
       } = beforeDepository;
 
       const uiRedeemableAmountUnderManagementCap = nativeToUi(
@@ -129,6 +145,7 @@ export const editMercurialVaultDepositorySuite = async function ({
         ']'
       );
       console.log('[🧾 mintingDisabled', mintingDisabled, ']');
+      console.log('[🧾 profitsBeneficiaryKey', profitsBeneficiaryKey, ']');
 
       await editMercurialVaultDepositoryTest({
         authority,

--- a/tests/suite/editMercurialVaultDepositorySuite.ts
+++ b/tests/suite/editMercurialVaultDepositorySuite.ts
@@ -107,17 +107,21 @@ export const editMercurialVaultDepositorySuite = async function ({
       });
     });
 
-    it(`Edit profitsBeneficiaryKey alone should work`, async function () {
-      const profitsBeneficiaryKey = new PublicKey('42');
+    it(`Edit profitsBeneficiaryCollateral alone should work`, async function () {
+      const profitsBeneficiaryCollateral = new PublicKey('42');
 
-      console.log('[🧾 profitsBeneficiaryKey', profitsBeneficiaryKey, ']');
+      console.log(
+        '[🧾 profitsBeneficiaryCollateral',
+        profitsBeneficiaryCollateral,
+        ']'
+      );
 
       await editMercurialVaultDepositoryTest({
         authority,
         controller,
         depository,
         uiFields: {
-          profitsBeneficiaryKey,
+          profitsBeneficiaryCollateral,
         },
       });
     });
@@ -129,7 +133,7 @@ export const editMercurialVaultDepositorySuite = async function ({
         redeemingFeeInBps,
         redeemableAmountUnderManagementCap,
         mintingDisabled,
-        profitsBeneficiaryKey,
+        profitsBeneficiaryCollateral,
       } = beforeDepository;
 
       const uiRedeemableAmountUnderManagementCap = nativeToUi(
@@ -145,7 +149,11 @@ export const editMercurialVaultDepositorySuite = async function ({
         ']'
       );
       console.log('[🧾 mintingDisabled', mintingDisabled, ']');
-      console.log('[🧾 profitsBeneficiaryKey', profitsBeneficiaryKey, ']');
+      console.log(
+        '[🧾 profitsBeneficiaryCollateral',
+        profitsBeneficiaryCollateral,
+        ']'
+      );
 
       await editMercurialVaultDepositoryTest({
         authority,

--- a/tests/test_integration.ts
+++ b/tests/test_integration.ts
@@ -32,6 +32,7 @@ describe('UXD Controller Suite', function () {
 });
 
 let user: Signer = new Keypair();
+let profitsBeneficiaryKey: Signer = new Keypair();
 
 describe('Mercurial vault integration tests: USDC', async function () {
   this.beforeAll('Setup: fund user', async function () {
@@ -68,6 +69,7 @@ describe('Mercurial vault integration tests: USDC', async function () {
     mercurialVaultDepositoryCollectProfitSuite({
       authority,
       controller,
+      profitsBeneficiaryKey,
       payer: bank,
     });
   });
@@ -77,6 +79,12 @@ describe('Mercurial vault integration tests: USDC', async function () {
       MERCURIAL_USDC_DEVNET,
       MERCURIAL_USDC_DEVNET_DECIMALS,
       user,
+      bank.publicKey
+    );
+    await transferAllTokens(
+      MERCURIAL_USDC_DEVNET,
+      MERCURIAL_USDC_DEVNET_DECIMALS,
+      profitsBeneficiaryKey,
       bank.publicKey
     );
     await transferAllSol(user, bank.publicKey);

--- a/tests/test_integration.ts
+++ b/tests/test_integration.ts
@@ -8,10 +8,7 @@ import {
   MERCURIAL_USDC_DEVNET_DECIMALS,
 } from './constants';
 import { transferAllSol, transferAllTokens, transferSol } from './utils';
-import {
-  controllerIntegrationSuite,
-  controllerIntegrationSuiteParameters,
-} from './suite/controllerIntegrationSuite';
+import { controllerIntegrationSuite } from './suite/controllerIntegrationSuite';
 import { mercurialVaultDepositorySetupSuite } from './suite/mercurialVaultDepositorySetup';
 import { mercurialVaultDepositoryMintRedeemSuite } from './suite/mercurialVaultMintAndRedeemSuite';
 import { editMercurialVaultDepositorySuite } from './suite/editMercurialVaultDepositorySuite';
@@ -32,7 +29,7 @@ describe('UXD Controller Suite', function () {
 });
 
 let user: Signer = new Keypair();
-let profitsBeneficiaryKey: Signer = new Keypair();
+let profitsBeneficiary: Signer = new Keypair();
 
 describe('Mercurial vault integration tests: USDC', async function () {
   this.beforeAll('Setup: fund user', async function () {
@@ -69,7 +66,7 @@ describe('Mercurial vault integration tests: USDC', async function () {
     mercurialVaultDepositoryCollectProfitSuite({
       authority,
       controller,
-      profitsBeneficiaryKey,
+      profitsBeneficiary,
       payer: bank,
     });
   });
@@ -84,7 +81,7 @@ describe('Mercurial vault integration tests: USDC', async function () {
     await transferAllTokens(
       MERCURIAL_USDC_DEVNET,
       MERCURIAL_USDC_DEVNET_DECIMALS,
-      profitsBeneficiaryKey,
+      profitsBeneficiary,
       bank.publicKey
     );
     await transferAllSol(user, bank.publicKey);


### PR DESCRIPTION
much similar to https://github.com/UXDProtocol/uxd-program/pull/221
except: 
- profits_beneficiary_collateral's owner compare directly with depository.profits_beneficiary_key, without passing the profits_beneficiary_key to context
- require non zero pubkey as profits_beneficiary_key when calling collect profit ix, abort otherwise
- added test for above scenraios


client PR: https://github.com/UXDProtocol/uxd-client/pull/37