### PR TITLE
[Safety] Hardening the automated tests and try to remove some flackyness

### DIFF
--- a/tests/cases/editControllerTest.ts
+++ b/tests/cases/editControllerTest.ts
@@ -51,8 +51,14 @@ export const editControllerTest = async function (
         redeemableGlobalSupplyCap_post.toNumber(),
         controller.redeemableMintDecimals
       );
-      expect(redeemableGlobalSupplyCap_postUi).equals(
-        uiFields.redeemableGlobalSupplyCap,
+      expect(
+        redeemableGlobalSupplyCap_postUi.toFixed(
+          controller.redeemableMintDecimals
+        )
+      ).equals(
+        uiFields.redeemableGlobalSupplyCap.toFixed(
+          controller.redeemableMintDecimals
+        ),
         'Redeemable Global Supply Cap must bet set'
       );
       console.log(

--- a/tests/cases/editCredixLpDepositoryTest.ts
+++ b/tests/cases/editCredixLpDepositoryTest.ts
@@ -67,8 +67,14 @@ export const editCredixLpDepositoryTest = async function (
         redeemableAmountUnderManagementCap_post,
         controller.redeemableMintDecimals
       );
-      expect(redeemableAmountUnderManagementCapUi).equals(
-        uiFields.redeemableAmountUnderManagementCap,
+      expect(
+        redeemableAmountUnderManagementCapUi.toFixed(
+          controller.redeemableMintDecimals
+        )
+      ).equals(
+        uiFields.redeemableAmountUnderManagementCap.toFixed(
+          controller.redeemableMintDecimals
+        ),
         'The redeemable depository supply cap has not changed.'
       );
       console.log(

--- a/tests/cases/editIdentityDepositoryTest.ts
+++ b/tests/cases/editIdentityDepositoryTest.ts
@@ -59,15 +59,21 @@ export const editIdentityDepositoryTest = async function (
         redeemableAmountUnderManagementCap_post,
         controller.redeemableMintDecimals
       );
-      expect(redeemableAmountUnderManagementCapUi).equals(
-        uiFields.redeemableAmountUnderManagementCap,
+      expect(
+        redeemableAmountUnderManagementCapUi.toFixed(
+          controller.redeemableMintDecimals
+        )
+      ).equals(
+        uiFields.redeemableAmountUnderManagementCap.toFixed(
+          controller.redeemableMintDecimals
+        ),
         'The redeemable depository supply cap has not changed.'
       );
       console.log(
         `🧾 Previous redeemable depository supply cap was`,
-        redeemableAmountUnderManagementCap.toString(),
+        redeemableAmountUnderManagementCap,
         'now is',
-        redeemableAmountUnderManagementCap_post.toString()
+        redeemableAmountUnderManagementCap_post
       );
     }
     if (typeof uiFields.mintingDisabled !== 'undefined') {

--- a/tests/cases/editMercurialVaultDepositoryTest.ts
+++ b/tests/cases/editMercurialVaultDepositoryTest.ts
@@ -67,15 +67,21 @@ export const editMercurialVaultDepositoryTest = async function (
         redeemableAmountUnderManagementCap_post,
         controller.redeemableMintDecimals
       );
-      expect(redeemableAmountUnderManagementCapUi).equals(
-        uiFields.redeemableAmountUnderManagementCap,
+      expect(
+        redeemableAmountUnderManagementCapUi.toFixed(
+          controller.redeemableMintDecimals
+        )
+      ).equals(
+        uiFields.redeemableAmountUnderManagementCap.toFixed(
+          controller.redeemableMintDecimals
+        ),
         'The redeemable depository supply cap has not changed.'
       );
       console.log(
         `🧾 Previous redeemable depository supply cap was`,
-        redeemableAmountUnderManagementCap.toString(),
+        redeemableAmountUnderManagementCap,
         'now is',
-        redeemableAmountUnderManagementCap_post.toString()
+        redeemableAmountUnderManagementCap_post
       );
     }
     if (typeof uiFields.mintingFeeInBps !== 'undefined') {

--- a/tests/suite/credixLpDepositoryMintAndRedeemSuite.ts
+++ b/tests/suite/credixLpDepositoryMintAndRedeemSuite.ts
@@ -12,9 +12,10 @@ import { BN } from '@project-serum/anchor';
 import { editCredixLpDepositoryTest } from '../cases/editCredixLpDepositoryTest';
 import { editControllerTest } from '../cases/editControllerTest';
 import { redeemFromCredixLpDepositoryTest } from '../cases/redeemFromCredixLpDepositoryTest';
+import { collectProfitOfCredixLpDepositoryTest } from '../cases/collectProfitOfCredixLpDepositoryTest';
 
 export const credixLpDepositoryMintAndRedeemSuite = async function (
-  controllerAuthority: Signer,
+  authority: Signer,
   user: Signer,
   payer: Signer,
   controller: Controller,
@@ -278,7 +279,7 @@ export const credixLpDepositoryMintAndRedeemSuite = async function (
 
   describe('Global redeemable supply cap overflow', () => {
     it('Set global redeemable supply cap to 0', () =>
-      editControllerTest(controllerAuthority, controller, {
+      editControllerTest(authority, controller, {
         redeemableGlobalSupplyCap: 0,
       }));
 
@@ -317,7 +318,7 @@ export const credixLpDepositoryMintAndRedeemSuite = async function (
         controller.redeemableMintDecimals
       );
 
-      await editControllerTest(controllerAuthority, controller, {
+      await editControllerTest(authority, controller, {
         redeemableGlobalSupplyCap: globalRedeemableSupplyCap,
       });
     });
@@ -330,18 +331,13 @@ export const credixLpDepositoryMintAndRedeemSuite = async function (
         TXN_OPTS
       );
 
-      await editCredixLpDepositoryTest(
-        controllerAuthority,
-        controller,
-        depository,
-        {
-          redeemableAmountUnderManagementCap:
-            nativeToUi(
-              onChainDepository.redeemableAmountUnderManagement,
-              controller.redeemableMintDecimals
-            ) + 0.0005,
-        }
-      );
+      await editCredixLpDepositoryTest(authority, controller, depository, {
+        redeemableAmountUnderManagementCap:
+          nativeToUi(
+            onChainDepository.redeemableAmountUnderManagement,
+            controller.redeemableMintDecimals
+          ) + 0.0005,
+      });
     });
 
     it(`Mint ${controller.redeemableMintSymbol} with 0.001 ${depository.collateralSymbol} (should fail)`, async function () {
@@ -379,27 +375,17 @@ export const credixLpDepositoryMintAndRedeemSuite = async function (
         controller.redeemableMintDecimals
       );
 
-      await editCredixLpDepositoryTest(
-        controllerAuthority,
-        controller,
-        depository,
-        {
-          redeemableAmountUnderManagementCap,
-        }
-      );
+      await editCredixLpDepositoryTest(authority, controller, depository, {
+        redeemableAmountUnderManagementCap,
+      });
     });
   });
 
   describe('Disabled minting', () => {
     it('Disable minting on credix lp depository', async function () {
-      await editCredixLpDepositoryTest(
-        controllerAuthority,
-        controller,
-        depository,
-        {
-          mintingDisabled: true,
-        }
-      );
+      await editCredixLpDepositoryTest(authority, controller, depository, {
+        mintingDisabled: true,
+      });
     });
 
     it(`Mint ${controller.redeemableMintSymbol} with 0.001 ${depository.collateralSymbol} (should fail)`, async function () {
@@ -429,13 +415,21 @@ export const credixLpDepositoryMintAndRedeemSuite = async function (
     });
 
     it(`Re-enable minting for credix lp depository`, async function () {
-      await editCredixLpDepositoryTest(
-        controllerAuthority,
+      await editCredixLpDepositoryTest(authority, controller, depository, {
+        mintingDisabled: false,
+      });
+    });
+  });
+
+  describe('Collection of Profits', () => {
+    it(`Collecting profit of credixLpDepository should work`, async function () {
+      console.log('[🧾 collectProfit]');
+
+      await collectProfitOfCredixLpDepositoryTest(
+        authority,
         controller,
         depository,
-        {
-          mintingDisabled: false,
-        }
+        payer
       );
     });
   });

--- a/tests/suite/credixLpDepositorySetupSuite.ts
+++ b/tests/suite/credixLpDepositorySetupSuite.ts
@@ -28,15 +28,4 @@ export const credixLpDepositorySetupSuite = function (
       redeemableAmountUnderManagementCap: 25_000_000,
     });
   });
-
-  it(`Collecting profit of credixLpDepository should work`, async function () {
-    console.log('[🧾 collectProfit]');
-
-    await collectProfitOfCredixLpDepositoryTest(
-      authority,
-      controller,
-      depository,
-      payer
-    );
-  });
 };

--- a/tests/suite/freezeProgramSuite.ts
+++ b/tests/suite/freezeProgramSuite.ts
@@ -29,6 +29,7 @@ export const freezeProgramSuite = async function (
   });
 
   it(`mintWithMercurialVaultDepositoryTest under frozen program`, async function () {
+    let failure = false;
     try {
       await mintWithMercurialVaultDepositoryTest(
         1,
@@ -38,12 +39,13 @@ export const freezeProgramSuite = async function (
         payer
       );
     } catch {
-      expect(true, 'Failing as planned');
+      failure = true;
     }
-    expect(false, 'Should have failed - program is frozen');
+    expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
   it(`redeemFromMercurialVaultDepositoryTest under frozen program`, async function () {
+    let failure = false;
     try {
       await redeemFromMercurialVaultDepositoryTest(
         1,
@@ -53,21 +55,23 @@ export const freezeProgramSuite = async function (
         payer
       );
     } catch {
-      expect(true, 'Failing as planned');
+      failure = true;
     }
-    expect(false, 'Should have failed - program is frozen');
+    expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
   it(`editControllerTest under frozen program`, async function () {
+    let failure = false;
     try {
       await editControllerTest(authority, controller, {});
     } catch {
-      expect(true, 'Failing as planned');
+      failure = true;
     }
-    expect(false, 'Should have failed - program is frozen');
+    expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
   it(`editIdentityDepositoryTest under frozen program`, async function () {
+    let failure = false;
     try {
       await editIdentityDepositoryTest(
         authority,
@@ -76,12 +80,13 @@ export const freezeProgramSuite = async function (
         {}
       );
     } catch {
-      expect(true, 'Failing as planned');
+      failure = true;
     }
-    expect(false, 'Should have failed - program is frozen');
+    expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
   it(`editMercurialVaultDepositoryTest under frozen program`, async function () {
+    let failure = false;
     try {
       await editMercurialVaultDepositoryTest(
         authority,
@@ -90,12 +95,13 @@ export const freezeProgramSuite = async function (
         {}
       );
     } catch {
-      expect(true, 'Failing as planned');
+      failure = true;
     }
-    expect(false, 'Should have failed - program is frozen');
+    expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
   it(`initializeIdentityDepositoryTest under frozen program`, async function () {
+    let failure = false;
     try {
       await initializeIdentityDepositoryTest(
         authority,
@@ -104,12 +110,13 @@ export const freezeProgramSuite = async function (
         payer
       );
     } catch {
-      expect(true, 'Failing as planned');
+      failure = true;
     }
-    expect(false, 'Should have failed - program is frozen');
+    expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
   it(`mintWithIdentityDepositoryTest under frozen program`, async function () {
+    let failure = false;
     try {
       await mintWithIdentityDepositoryTest(
         1,
@@ -119,12 +126,13 @@ export const freezeProgramSuite = async function (
         payer
       );
     } catch {
-      expect(true, 'Failing as planned');
+      failure = true;
     }
-    expect(false, 'Should have failed - program is frozen');
+    expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
   it(`redeemFromIdentityDepositoryTest under frozen program`, async function () {
+    let failure = false;
     try {
       await redeemFromIdentityDepositoryTest(
         1,
@@ -134,12 +142,13 @@ export const freezeProgramSuite = async function (
         payer
       );
     } catch {
-      expect(true, 'Failing as planned');
+      failure = true;
     }
-    expect(false, 'Should have failed - program is frozen');
+    expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
   it(`registerMercurialVaultDepositoryTest under frozen program`, async function () {
+    let failure = false;
     try {
       await registerMercurialVaultDepositoryTest(
         authority,
@@ -151,9 +160,9 @@ export const freezeProgramSuite = async function (
         payer
       );
     } catch {
-      expect(true, 'Failing as planned');
+      failure = true;
     }
-    expect(false, 'Should have failed - program is frozen');
+    expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
   after(`Resume program`, async function () {

--- a/tests/suite/freezeProgramSuite.ts
+++ b/tests/suite/freezeProgramSuite.ts
@@ -11,14 +11,12 @@ import { editControllerTest } from '../cases/editControllerTest';
 import { editIdentityDepositoryTest } from '../cases/editIdentityDepositoryTest';
 import { editMercurialVaultDepositoryTest } from '../cases/editMercurialVaultDepositoryTest';
 import { freezeProgramTest } from '../cases/freezeProgramTest';
-import { initializeIdentityDepositoryTest } from '../cases/InitializeIdentityDepositoryTest';
 import { mintWithCredixLpDepositoryTest } from '../cases/mintWithCredixLpDepositoryTest';
 import { mintWithIdentityDepositoryTest } from '../cases/mintWithIdentityDepositoryTest';
 import { mintWithMercurialVaultDepositoryTest } from '../cases/mintWithMercurialVaultDepositoryTest';
 import { redeemFromCredixLpDepositoryTest } from '../cases/redeemFromCredixLpDepositoryTest';
 import { redeemFromIdentityDepositoryTest } from '../cases/redeemFromIdentityDepositoryTest';
 import { redeemFromMercurialVaultDepositoryTest } from '../cases/redeemFromMercurialVaultDepositoryTest';
-import { registerMercurialVaultDepositoryTest } from '../cases/registerMercurialVaultDepositoryTest';
 
 export const freezeProgramSuite = async function (
   authority: Signer,
@@ -152,21 +150,6 @@ export const freezeProgramSuite = async function (
     expect(failure).eq(true, 'Should have failed - program is frozen');
   });
 
-  it(`initializeIdentityDepositoryTest under frozen program`, async function () {
-    let failure = false;
-    try {
-      await initializeIdentityDepositoryTest(
-        authority,
-        controller,
-        identityDepository,
-        payer
-      );
-    } catch {
-      failure = true;
-    }
-    expect(failure).eq(true, 'Should have failed - program is frozen');
-  });
-
   it(`mintWithIdentityDepositoryTest under frozen program`, async function () {
     let failure = false;
     try {
@@ -191,24 +174,6 @@ export const freezeProgramSuite = async function (
         user,
         controller,
         identityDepository,
-        payer
-      );
-    } catch {
-      failure = true;
-    }
-    expect(failure).eq(true, 'Should have failed - program is frozen');
-  });
-
-  it(`registerMercurialVaultDepositoryTest under frozen program`, async function () {
-    let failure = false;
-    try {
-      await registerMercurialVaultDepositoryTest(
-        authority,
-        controller,
-        mercurialVaultDepository,
-        1,
-        1,
-        1,
         payer
       );
     } catch {

--- a/tests/suite/freezeProgramSuite.ts
+++ b/tests/suite/freezeProgramSuite.ts
@@ -1,17 +1,21 @@
 import { Signer } from '@solana/web3.js';
 import {
+  CredixLpDepository,
   IdentityDepository,
   MercurialVaultDepository,
 } from '@uxd-protocol/uxd-client';
 import { Controller } from '@uxd-protocol/uxd-client';
 import { expect } from 'chai';
+import { collectProfitOfCredixLpDepositoryTest } from '../cases/collectProfitOfCredixLpDepositoryTest';
 import { editControllerTest } from '../cases/editControllerTest';
 import { editIdentityDepositoryTest } from '../cases/editIdentityDepositoryTest';
 import { editMercurialVaultDepositoryTest } from '../cases/editMercurialVaultDepositoryTest';
 import { freezeProgramTest } from '../cases/freezeProgramTest';
 import { initializeIdentityDepositoryTest } from '../cases/InitializeIdentityDepositoryTest';
+import { mintWithCredixLpDepositoryTest } from '../cases/mintWithCredixLpDepositoryTest';
 import { mintWithIdentityDepositoryTest } from '../cases/mintWithIdentityDepositoryTest';
 import { mintWithMercurialVaultDepositoryTest } from '../cases/mintWithMercurialVaultDepositoryTest';
+import { redeemFromCredixLpDepositoryTest } from '../cases/redeemFromCredixLpDepositoryTest';
 import { redeemFromIdentityDepositoryTest } from '../cases/redeemFromIdentityDepositoryTest';
 import { redeemFromMercurialVaultDepositoryTest } from '../cases/redeemFromMercurialVaultDepositoryTest';
 import { registerMercurialVaultDepositoryTest } from '../cases/registerMercurialVaultDepositoryTest';
@@ -22,6 +26,7 @@ export const freezeProgramSuite = async function (
   payer: Signer,
   controller: Controller,
   mercurialVaultDepository: MercurialVaultDepository,
+  credixLpDepository: CredixLpDepository,
   identityDepository: IdentityDepository
 ) {
   before(`Freeze program`, async function () {
@@ -52,6 +57,53 @@ export const freezeProgramSuite = async function (
         user,
         controller,
         mercurialVaultDepository,
+        payer
+      );
+    } catch {
+      failure = true;
+    }
+    expect(failure).eq(true, 'Should have failed - program is frozen');
+  });
+
+  it(`mintWithCredixLpDepositoryTest under frozen program`, async function () {
+    let failure = false;
+    try {
+      await mintWithCredixLpDepositoryTest(
+        1,
+        user,
+        controller,
+        credixLpDepository,
+        payer
+      );
+    } catch {
+      failure = true;
+    }
+    expect(failure).eq(true, 'Should have failed - program is frozen');
+  });
+
+  it(`redeemFromCredixLpDepositoryTest under frozen program`, async function () {
+    let failure = false;
+    try {
+      await redeemFromCredixLpDepositoryTest(
+        1,
+        user,
+        controller,
+        credixLpDepository,
+        payer
+      );
+    } catch {
+      failure = true;
+    }
+    expect(failure).eq(true, 'Should have failed - program is frozen');
+  });
+
+  it(`collectProfitOfCredixLpDepositoryTest under frozen program`, async function () {
+    let failure = false;
+    try {
+      await collectProfitOfCredixLpDepositoryTest(
+        payer,
+        controller,
+        credixLpDepository,
         payer
       );
     } catch {

--- a/tests/suite/identityDepositoryMintAndRedeemSuite.ts
+++ b/tests/suite/identityDepositoryMintAndRedeemSuite.ts
@@ -264,32 +264,20 @@ export const identityDepositoryMintRedeemSuite = async function (
       }
     );
 
-    it(`Mint for 1 native unit ${depository.collateralMintSymbol}`, async function () {
+    it(`Mint for 1 native unit ${depository.collateralMintSymbol} (should succeed, because no precision loss on identity)`, async function () {
       const collateralAmount = Math.pow(10, -depository.collateralMintDecimals);
-
       console.log(
         '[🧾 collateralAmount',
         collateralAmount,
         depository.collateralMintSymbol,
         ']'
       );
-
-      let failure = false;
-      try {
-        await mintWithIdentityDepositoryTest(
-          collateralAmount,
-          user,
-          controller,
-          depository,
-          payer
-        );
-      } catch {
-        failure = true;
-      }
-
-      expect(failure).eq(
-        true,
-        `Should have failed - User cannot mint for 0 ${controller.redeemableMintSymbol} (happens due to precision loss and fees)`
+      await mintWithIdentityDepositoryTest(
+        collateralAmount,
+        user,
+        controller,
+        depository,
+        payer
       );
     });
 

--- a/tests/suite/identityDepositoryMintAndRedeemSuite.ts
+++ b/tests/suite/identityDepositoryMintAndRedeemSuite.ts
@@ -135,7 +135,6 @@ export const identityDepositoryMintRedeemSuite = async function (
       );
 
       let failure = false;
-      let failure = false;
       try {
         await mintWithIdentityDepositoryTest(
           collateralAmount,

--- a/tests/suite/identityDepositoryMintAndRedeemSuite.ts
+++ b/tests/suite/identityDepositoryMintAndRedeemSuite.ts
@@ -134,6 +134,8 @@ export const identityDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
+      let failure = false;
       try {
         await mintWithIdentityDepositoryTest(
           collateralAmount,
@@ -143,11 +145,11 @@ export const identityDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - Do not own enough ${depository.collateralMintSymbol}`
       );
     });
@@ -162,6 +164,7 @@ export const identityDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await redeemFromIdentityDepositoryTest(
           redeemableAmount,
@@ -171,11 +174,11 @@ export const identityDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - Only owned ${initialRedeemableAccountBalance} ${controller.redeemableMintSymbol}`
       );
     });
@@ -190,6 +193,7 @@ export const identityDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await mintWithIdentityDepositoryTest(
           collateralAmount,
@@ -199,11 +203,11 @@ export const identityDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - Cannot mint for 0 ${depository.collateralMintSymbol}`
       );
     });
@@ -218,6 +222,7 @@ export const identityDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await redeemFromIdentityDepositoryTest(
           redeemableAmount,
@@ -227,11 +232,11 @@ export const identityDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - Cannot redeem for 0 ${controller.redeemableMintSymbol}`
       );
     });
@@ -270,6 +275,7 @@ export const identityDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await mintWithIdentityDepositoryTest(
           collateralAmount,
@@ -279,11 +285,11 @@ export const identityDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - User cannot mint for 0 ${controller.redeemableMintSymbol} (happens due to precision loss and fees)`
       );
     });
@@ -330,6 +336,7 @@ export const identityDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await mintWithIdentityDepositoryTest(
           collateralAmount,
@@ -339,11 +346,11 @@ export const identityDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - amount of redeemable overflow the global redeemable supply cap`
       );
     });
@@ -391,6 +398,7 @@ export const identityDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await mintWithIdentityDepositoryTest(
           collateralAmount,
@@ -400,11 +408,11 @@ export const identityDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - amount of redeemable overflow the redeemable depository supply cap`
       );
     });
@@ -448,6 +456,7 @@ export const identityDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await mintWithIdentityDepositoryTest(
           collateralAmount,
@@ -457,10 +466,10 @@ export const identityDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(false, `Should have failed - minting is disabled`);
+      expect(failure).eq(true, `Should have failed - minting is disabled`);
     });
 
     it(`Re-enable minting for identity depository`, async function () {

--- a/tests/suite/mercurialVaultMintAndRedeemSuite.ts
+++ b/tests/suite/mercurialVaultMintAndRedeemSuite.ts
@@ -121,6 +121,7 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await mintWithMercurialVaultDepositoryTest(
           collateralAmount,
@@ -130,11 +131,11 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - Do not own enough ${depository.collateralMint.symbol}`
       );
     });
@@ -149,6 +150,7 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await redeemFromMercurialVaultDepositoryTest(
           redeemableAmount,
@@ -158,11 +160,11 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - Only owned ${initialRedeemableAccountBalance} ${controller.redeemableMintSymbol}`
       );
     });
@@ -177,6 +179,7 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await mintWithMercurialVaultDepositoryTest(
           collateralAmount,
@@ -186,11 +189,11 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - Cannot mint for 0 ${depository.collateralMint.symbol}`
       );
     });
@@ -205,6 +208,7 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await redeemFromMercurialVaultDepositoryTest(
           redeemableAmount,
@@ -214,11 +218,11 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - Cannot redeem for 0 ${controller.redeemableMintSymbol}`
       );
     });
@@ -260,6 +264,7 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await mintWithMercurialVaultDepositoryTest(
           collateralAmount,
@@ -269,11 +274,11 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - User cannot mint for 0 ${controller.redeemableMintSymbol} (happens due to precision loss and fees)`
       );
     });
@@ -288,6 +293,7 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await redeemFromMercurialVaultDepositoryTest(
           redeemableAmount,
@@ -297,11 +303,11 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - User cannot get 0 ${controller.redeemableMintSymbol} from redeem (happens due to precision loss and fees)`
       );
     });
@@ -348,6 +354,7 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
       try {
         await mintWithMercurialVaultDepositoryTest(
           collateralAmount,
@@ -357,11 +364,11 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - amount of redeemable overflow the global redeemable supply cap`
       );
     });
@@ -409,6 +416,8 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
+      let failure = false;
       try {
         await mintWithMercurialVaultDepositoryTest(
           collateralAmount,
@@ -418,11 +427,11 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(
-        false,
+      expect(failure).eq(
+        true,
         `Should have failed - amount of redeemable overflow the redeemable depository supply cap`
       );
     });
@@ -466,6 +475,8 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
         ']'
       );
 
+      let failure = false;
+      let failure = false;
       try {
         await mintWithMercurialVaultDepositoryTest(
           collateralAmount,
@@ -475,10 +486,10 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
           payer
         );
       } catch {
-        expect(true, 'Failing as planned');
+        failure = true;
       }
 
-      expect(false, `Should have failed - minting is disabled`);
+      expect(failure).eq(true, `Should have failed - minting is disabled`);
     });
 
     it(`Re-enable minting for mercurial vault depository`, async function () {

--- a/tests/suite/mercurialVaultMintAndRedeemSuite.ts
+++ b/tests/suite/mercurialVaultMintAndRedeemSuite.ts
@@ -476,7 +476,6 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
       );
 
       let failure = false;
-      let failure = false;
       try {
         await mintWithMercurialVaultDepositoryTest(
           collateralAmount,

--- a/tests/suite/mercurialVaultMintAndRedeemSuite.ts
+++ b/tests/suite/mercurialVaultMintAndRedeemSuite.ts
@@ -417,7 +417,6 @@ export const mercurialVaultDepositoryMintRedeemSuite = async function (
       );
 
       let failure = false;
-      let failure = false;
       try {
         await mintWithMercurialVaultDepositoryTest(
           collateralAmount,

--- a/tests/test_ci_setup.ts
+++ b/tests/test_ci_setup.ts
@@ -17,8 +17,10 @@ import {
   controllerIntegrationSuiteParameters,
   controllerIntegrationSuite,
 } from './suite/controllerIntegrationSuite';
+import { credixLpDepositorySetupSuite } from './suite/credixLpDepositorySetupSuite';
 import { identityDepositorySetupSuite } from './suite/identityDepositorySetup';
 import { mercurialVaultDepositorySetupSuite } from './suite/mercurialVaultDepositorySetup';
+import { createCredixLpDepositoryDevnetUSDC } from './utils';
 
 (async () => {
   const controllerUXD = new Controller('UXD', UXD_DECIMALS, uxdProgramId);
@@ -43,6 +45,8 @@ import { mercurialVaultDepositorySetupSuite } from './suite/mercurialVaultDeposi
     uxdProgramId,
   });
 
+  const credixLpDepository = await createCredixLpDepositoryDevnetUSDC();
+
   const mintingFeeInBps = 0;
   const redeemingFeeInBps = 5;
   const uiRedeemableDepositorySupplyCap = 1_000;
@@ -53,6 +57,18 @@ import { mercurialVaultDepositorySetupSuite } from './suite/mercurialVaultDeposi
       bank,
       controllerUXD,
       mercurialVaultDepository,
+      mintingFeeInBps,
+      redeemingFeeInBps,
+      uiRedeemableDepositorySupplyCap
+    );
+  });
+
+  describe('credixLpDepositorySetupSuite', function () {
+    credixLpDepositorySetupSuite(
+      authority,
+      bank,
+      controllerUXD,
+      credixLpDepository,
       mintingFeeInBps,
       redeemingFeeInBps,
       uiRedeemableDepositorySupplyCap

--- a/tests/test_development.ts
+++ b/tests/test_development.ts
@@ -6,6 +6,7 @@ import {
   IdentityDepository,
   USDC_DEVNET,
   USDC_DECIMALS,
+  CredixLpDepository,
 } from '@uxd-protocol/uxd-client';
 import {
   authority,
@@ -15,6 +16,7 @@ import {
   uxdProgramId,
 } from './constants';
 import {
+  createCredixLpDepositoryDevnetUSDC,
   transferAllSol,
   transferAllTokens,
   transferSol,
@@ -49,6 +51,8 @@ import { editControllerTest } from './cases/editControllerTest';
     },
     uxdProgramId,
   });
+
+  let credixLpDepository = await createCredixLpDepositoryDevnetUSDC();
 
   const identityDepository = new IdentityDepository(
     USDC_DEVNET,
@@ -88,6 +92,7 @@ import { editControllerTest } from './cases/editControllerTest';
         bank,
         controller,
         mercurialVaultDepository,
+        credixLpDepository,
         identityDepository
       );
     });


### PR DESCRIPTION
Trying to make the tests more robust:
- try to make the expect less prone to precision error
- make sure the failure tests are actually testing failure instead of succeeding all the time

example flacky failure that should not be fixed:
- https://github.com/UXDProtocol/uxd-program/actions/runs/3928184907/jobs/6715597708