### PR TITLE
[Rebalancing] [Part 0.3] Enforcing strict account sizes

### DIFF
--- a/programs/uxd/src/state/controller.rs
+++ b/programs/uxd/src/state/controller.rs
@@ -6,26 +6,27 @@ pub const MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES: usize = 4;
 pub const MAX_REGISTERED_CREDIX_LP_DEPOSITORIES: usize = 4;
 
 // Total should be 885 bytes
+pub const CONTROLLER_RESERVED_SPACE: usize = 230;
 pub const CONTROLLER_SPACE: usize = 8
-    + 1
-    + 1
-    + 1
-    + 32
-    + 32
-    + 1
-    + 255 // Shh. Free real estate
-    + 1
-    + 1
-    + 16
-    + 8 // unused
-    + 16
-    + 8 // unused
-    + (32 * MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES)
-    + 1
-    + (32 * MAX_REGISTERED_CREDIX_LP_DEPOSITORIES)
-    + 1
-    + 16
-    + 230;
+    + 1 // bump
+    + 1 // redeemable_mint_bump
+    + 1 // version
+    + 32 // authority
+    + 32 // redeemable_mint
+    + 1 // redeemable_mint_decimals
+    + 255 // _unused, Shh. Free real estate
+    + 1 // is_frozen
+    + 1 // _unused2
+    + 16 // redeemable_global_supply_cap
+    + 8 // _unused3
+    + 16 // redeemable_circulating_supply
+    + 8 // _unused4
+    + (32 * MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES) // registered_mercurial_vault_depositories
+    + 1 // registered_mercurial_vault_depositories_count
+    + (32 * MAX_REGISTERED_CREDIX_LP_DEPOSITORIES) // registered_credix_lp_depositories
+    + 1 // registered_credix_lp_depositories_count
+    + 16 // profits_total_collected
+    + CONTROLLER_RESERVED_SPACE;
 
 #[account(zero_copy)]
 #[repr(packed)]
@@ -74,6 +75,8 @@ pub struct Controller {
     //
     // Total amount of profits collected into the treasury by any depository
     pub profits_total_collected: u128,
+    // For future usage
+    pub _reserved: [u8; CONTROLLER_RESERVED_SPACE],
 }
 
 impl Controller {

--- a/programs/uxd/src/state/controller.rs
+++ b/programs/uxd/src/state/controller.rs
@@ -1,3 +1,5 @@
+use std::mem::size_of;
+
 use crate::error::UxdError;
 use crate::utils::checked_add_u128_and_i128;
 use anchor_lang::prelude::*;
@@ -8,24 +10,24 @@ pub const MAX_REGISTERED_CREDIX_LP_DEPOSITORIES: usize = 4;
 // Total should be 885 bytes
 pub const CONTROLLER_RESERVED_SPACE: usize = 230;
 pub const CONTROLLER_SPACE: usize = 8
-    + 1 // bump
-    + 1 // redeemable_mint_bump
-    + 1 // version
-    + 32 // authority
-    + 32 // redeemable_mint
-    + 1 // redeemable_mint_decimals
+    + size_of::<u8>() // bump
+    + size_of::<u8>() // redeemable_mint_bump
+    + size_of::<u8>() // version
+    + size_of::<Pubkey>() // authority
+    + size_of::<Pubkey>() // redeemable_mint
+    + size_of::<u8>() // redeemable_mint_decimals
     + 255 // _unused, Shh. Free real estate
-    + 1 // is_frozen
-    + 1 // _unused2
-    + 16 // redeemable_global_supply_cap
+    + size_of::<bool>() // is_frozen
+    + size_of::<u8>() // _unused2
+    + size_of::<u128>() // redeemable_global_supply_cap
     + 8 // _unused3
-    + 16 // redeemable_circulating_supply
-    + 8 // _unused4
-    + (32 * MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES) // registered_mercurial_vault_depositories
-    + 1 // registered_mercurial_vault_depositories_count
-    + (32 * MAX_REGISTERED_CREDIX_LP_DEPOSITORIES) // registered_credix_lp_depositories
-    + 1 // registered_credix_lp_depositories_count
-    + 16 // profits_total_collected
+    + size_of::<u128>() // redeemable_circulating_supply
+    +  8 // _unused4
+    + size_of::<Pubkey>() * MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES // registered_mercurial_vault_depositories
+    + size_of::<u8>() // registered_mercurial_vault_depositories_count
+    + size_of::<Pubkey>() * MAX_REGISTERED_CREDIX_LP_DEPOSITORIES // registered_credix_lp_depositories
+    + size_of::<u8>() // registered_credix_lp_depositories_count
+    + size_of::<u128>() // profits_total_collected
     + CONTROLLER_RESERVED_SPACE;
 
 #[account(zero_copy)]

--- a/programs/uxd/src/state/controller.rs
+++ b/programs/uxd/src/state/controller.rs
@@ -18,11 +18,11 @@ pub const CONTROLLER_SPACE: usize = 8
     + size_of::<u8>() // redeemable_mint_decimals
     + 255 // _unused, Shh. Free real estate
     + size_of::<bool>() // is_frozen
-    + size_of::<u8>() // _unused2
+    + 1 // _unused2
     + size_of::<u128>() // redeemable_global_supply_cap
     + 8 // _unused3
     + size_of::<u128>() // redeemable_circulating_supply
-    +  8 // _unused4
+    + 8 // _unused4
     + size_of::<Pubkey>() * MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES // registered_mercurial_vault_depositories
     + size_of::<u8>() // registered_mercurial_vault_depositories_count
     + size_of::<Pubkey>() * MAX_REGISTERED_CREDIX_LP_DEPOSITORIES // registered_credix_lp_depositories

--- a/programs/uxd/src/state/credix_lp_depository.rs
+++ b/programs/uxd/src/state/credix_lp_depository.rs
@@ -4,6 +4,7 @@ use anchor_lang::prelude::*;
 
 use crate::error::UxdError;
 
+pub const CREDIX_LP_DEPOSITORY_RESERVED_SPACE: usize = 768;
 pub const CREDIX_LP_DEPOSITORY_SPACE: usize = 8 // anchor-pad
  + size_of::<u8>() // bump
  + size_of::<u8>() // version
@@ -33,7 +34,7 @@ pub const CREDIX_LP_DEPOSITORY_SPACE: usize = 8 // anchor-pad
  + size_of::<u128>() // profits_total_collected
  + size_of::<Pubkey>() // profits_beneficiary_collateral
 
- + 768; // reserved space
+ + CREDIX_LP_DEPOSITORY_RESERVED_SPACE; // reserved space
 
 #[account(zero_copy)]
 #[repr(packed)]
@@ -75,6 +76,9 @@ pub struct CredixLpDepository {
     // Collection of the depository's profits
     pub profits_total_collected: u128,
     pub profits_beneficiary_collateral: Pubkey,
+
+    // For future usage
+    pub _reserved: [u8; CREDIX_LP_DEPOSITORY_RESERVED_SPACE],
 }
 
 impl CredixLpDepository {

--- a/programs/uxd/src/state/credix_lp_depository.rs
+++ b/programs/uxd/src/state/credix_lp_depository.rs
@@ -34,7 +34,7 @@ pub const CREDIX_LP_DEPOSITORY_SPACE: usize = 8 // anchor-pad
  + size_of::<u128>() // profits_total_collected
  + size_of::<Pubkey>() // profits_beneficiary_collateral
 
- + CREDIX_LP_DEPOSITORY_RESERVED_SPACE; // reserved space
+ + CREDIX_LP_DEPOSITORY_RESERVED_SPACE;
 
 #[account(zero_copy)]
 #[repr(packed)]

--- a/programs/uxd/src/state/identity_depository.rs
+++ b/programs/uxd/src/state/identity_depository.rs
@@ -1,18 +1,22 @@
+use std::mem::size_of;
+
 use anchor_lang::prelude::*;
 
 pub const IDENTITY_DEPOSITORY_RESERVED_SPACE: usize = 512;
 pub const IDENTITY_DEPOSITORY_SPACE: usize = 8
-    + 1 // bump
-    + 1 // version
-    + 32 // collateral_mint
-    + 1 // collateral_mint_decimal
-    + 32 // collateral_vault
-    + 1 // collateral_vault_bump
-    + 16 // collateral_amount_deposited
-    + 16 // redeemable_under_management
-    + 16 // redeemable_under_management_cap
-    + 1 // regular_minting_disabled
-    + 3 // mango_collateral_reinjected_wsol/btc/eth
+    + size_of::<u8>() // bump
+    + size_of::<u8>() // version
+    + size_of::<Pubkey>() // collateral_mint
+    + size_of::<u8>() // collateral_mint_decimal
+    + size_of::<Pubkey>() // collateral_vault
+    + size_of::<u8>() // collateral_vault_bump
+    + size_of::<u128>() // collateral_amount_deposited
+    + size_of::<u128>() // redeemable_amount_under_management
+    + size_of::<u128>() // redeemable_amount_under_management_cap
+    + size_of::<bool>() // minting_disabled
+    + size_of::<bool>() // mango_collateral_reinjected_wsol
+    + size_of::<bool>() // mango_collateral_reinjected_btc
+    + size_of::<bool>() // mango_collateral_reinjected_eth
     + IDENTITY_DEPOSITORY_RESERVED_SPACE;
 
 #[account(zero_copy)]

--- a/programs/uxd/src/state/identity_depository.rs
+++ b/programs/uxd/src/state/identity_depository.rs
@@ -44,4 +44,6 @@ pub struct IdentityDepository {
     pub mango_collateral_reinjected_wsol: bool,
     pub mango_collateral_reinjected_btc: bool,
     pub mango_collateral_reinjected_eth: bool,
+    // For future usage
+    pub _reserved: [u8; IDENTITY_DEPOSITORY_RESERVED_SPACE],
 }

--- a/programs/uxd/src/state/mercurial_vault_depository.rs
+++ b/programs/uxd/src/state/mercurial_vault_depository.rs
@@ -95,6 +95,9 @@ pub struct MercurialVaultDepository {
 
     // Receiver of the depository's profits
     pub profits_beneficiary_collateral: Pubkey,
+
+    // For future usage
+    pub _reserved: [u8; MERCURIAL_VAULT_RESERVED_SPACE],
 }
 
 impl MercurialVaultDepository {

--- a/programs/uxd/tests/unit_tests/state/controller.rs
+++ b/programs/uxd/tests/unit_tests/state/controller.rs
@@ -1,0 +1,14 @@
+// Unit tests
+#[cfg(test)]
+mod test_controller {
+    use anchor_lang::Result;
+    use std::mem::size_of;
+    use uxd::state::controller::CONTROLLER_SPACE;
+
+    #[test]
+    fn test_controller_space() -> Result<()> {
+        assert_eq!(CONTROLLER_SPACE, 885);
+        assert_eq!(size_of::<uxd::state::Controller>(), CONTROLLER_SPACE - 8);
+        Ok(())
+    }
+}

--- a/programs/uxd/tests/unit_tests/state/credix_lp_depository.rs
+++ b/programs/uxd/tests/unit_tests/state/credix_lp_depository.rs
@@ -2,11 +2,16 @@
 #[cfg(test)]
 mod test_credix_lp_depository {
     use anchor_lang::Result;
+    use std::mem::size_of;
     use uxd::state::credix_lp_depository::CREDIX_LP_DEPOSITORY_SPACE;
 
     #[test]
     fn test_credix_lp_depository_space() -> Result<()> {
         assert_eq!(CREDIX_LP_DEPOSITORY_SPACE, 1197);
+        assert_eq!(
+            size_of::<uxd::state::credix_lp_depository::CredixLpDepository>(),
+            CREDIX_LP_DEPOSITORY_SPACE - 8
+        );
         Ok(())
     }
 }

--- a/programs/uxd/tests/unit_tests/state/identity_depository.rs
+++ b/programs/uxd/tests/unit_tests/state/identity_depository.rs
@@ -1,0 +1,17 @@
+// Unit tests
+#[cfg(test)]
+mod test_identity_depository {
+    use anchor_lang::Result;
+    use std::mem::size_of;
+    use uxd::state::identity_depository::IDENTITY_DEPOSITORY_SPACE;
+
+    #[test]
+    fn test_identity_depository_space() -> Result<()> {
+        assert_eq!(IDENTITY_DEPOSITORY_SPACE, 640);
+        assert_eq!(
+            size_of::<uxd::state::identity_depository::IdentityDepository>(),
+            IDENTITY_DEPOSITORY_SPACE - 8
+        );
+        Ok(())
+    }
+}

--- a/programs/uxd/tests/unit_tests/state/mercurial_depository.rs
+++ b/programs/uxd/tests/unit_tests/state/mercurial_depository.rs
@@ -1,11 +1,16 @@
 #[cfg(test)]
 mod test_mercurial_depository {
     use anchor_lang::Result;
+    use std::mem::size_of;
     use uxd::state::mercurial_vault_depository::MERCURIAL_VAULT_DEPOSITORY_SPACE;
 
     #[test]
     fn test_mercurial_depository_space() -> Result<()> {
         assert_eq!(MERCURIAL_VAULT_DEPOSITORY_SPACE, 900);
+        assert_eq!(
+            size_of::<uxd::state::mercurial_vault_depository::MercurialVaultDepository>(),
+            MERCURIAL_VAULT_DEPOSITORY_SPACE - 8
+        );
         Ok(())
     }
 }

--- a/programs/uxd/tests/unit_tests/state/mercurial_vault_depository.rs
+++ b/programs/uxd/tests/unit_tests/state/mercurial_vault_depository.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
-mod test_mercurial_depository {
+mod test_mercurial_vault_depository {
     use anchor_lang::Result;
     use std::mem::size_of;
     use uxd::state::mercurial_vault_depository::MERCURIAL_VAULT_DEPOSITORY_SPACE;
 
     #[test]
-    fn test_mercurial_depository_space() -> Result<()> {
+    fn test_mercurial_vault_depository_space() -> Result<()> {
         assert_eq!(MERCURIAL_VAULT_DEPOSITORY_SPACE, 900);
         assert_eq!(
             size_of::<uxd::state::mercurial_vault_depository::MercurialVaultDepository>(),

--- a/programs/uxd/tests/unit_tests/state/mod.rs
+++ b/programs/uxd/tests/unit_tests/state/mod.rs
@@ -1,4 +1,4 @@
 mod controller;
 mod credix_lp_depository;
 mod identity_depository;
-mod mercurial_depository;
+mod mercurial_vault_depository;

--- a/programs/uxd/tests/unit_tests/state/mod.rs
+++ b/programs/uxd/tests/unit_tests/state/mod.rs
@@ -1,2 +1,4 @@
+mod controller;
 mod credix_lp_depository;
+mod identity_depository;
 mod mercurial_depository;


### PR DESCRIPTION
When trying to deserialize an account's data, anchor will throw an error if the size of the datastructure is smaller than the size of the on-chain accounts.

Therefore:
- we need to add the reserved space inside of the accounts data structure so that anchor can parse it
- to harden this process, I created new unit tests and double checked the correctness of the accounts sizes by using the extra explicit notation