### PR TITLE
[Quality Of Life] Hardening rust lints using --all-targets

### DIFF
--- a/.github/workflows/ci-cargo-lint-test.yml
+++ b/.github/workflows/ci-cargo-lint-test.yml
@@ -62,7 +62,7 @@ jobs:
 
       # Run cargo clippy
       - name: Run clippy
-        run: cargo clippy -- --deny=warnings
+        run: cargo clippy --all-targets -- --deny=warnings
 
   tests:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typescript": "^4.5.5"
   },
   "scripts": {
-    "source-lint": "cargo clippy",
+    "source-lint": "cargo clippy --all-targets",
     "source-format": "cargo fmt",
     "source-format-check": "cargo fmt --check",
     "tests-lint": "tsc --noEmit --pretty",

--- a/programs/uxd/tests/integration_tests/api/program_spl/instructions/process_lamports_airdrop.rs
+++ b/programs/uxd/tests/integration_tests/api/program_spl/instructions/process_lamports_airdrop.rs
@@ -11,7 +11,7 @@ pub async fn process_lamports_airdrop(
     lamports: u64,
 ) -> Result<(), program_test_context::ProgramTestError> {
     let from = Keypair::from_bytes(&program_test_context.payer.to_bytes())
-        .map_err(|e| program_test_context::ProgramTestError::SignatureError(e.to_string()))?;
-    let instruction = solana_program::system_instruction::transfer(&from.pubkey(), &to, lamports);
+        .map_err(|e| program_test_context::ProgramTestError::Signature(e.to_string()))?;
+    let instruction = solana_program::system_instruction::transfer(&from.pubkey(), to, lamports);
     program_test_context::process_instruction(program_test_context, instruction, &from).await
 }

--- a/programs/uxd/tests/integration_tests/api/program_spl/instructions/process_token_mint_init.rs
+++ b/programs/uxd/tests/integration_tests/api/program_spl/instructions/process_token_mint_init.rs
@@ -18,7 +18,7 @@ pub async fn process_token_mint_init(
         .banks_client
         .get_rent()
         .await
-        .map_err(|e| program_test_context::ProgramTestError::BanksClientError(e))?;
+        .map_err(program_test_context::ProgramTestError::BanksClient)?;
 
     let instruction_create = solana_program::system_instruction::create_account(
         &payer.pubkey(),
@@ -42,7 +42,7 @@ pub async fn process_token_mint_init(
         Some(authority),
         decimals,
     )
-    .map_err(|e| program_test_context::ProgramTestError::ProgramError(e))?;
+    .map_err(program_test_context::ProgramTestError::Program)?;
 
     program_test_context::process_instruction(program_test_context, instruction_init, payer)
         .await?;

--- a/programs/uxd/tests/integration_tests/api/program_spl/instructions/process_token_mint_to.rs
+++ b/programs/uxd/tests/integration_tests/api/program_spl/instructions/process_token_mint_to.rs
@@ -21,7 +21,7 @@ pub async fn process_token_mint_to(
         &[],
         amount,
     )
-    .map_err(|e| program_test_context::ProgramTestError::ProgramError(e))?;
+    .map_err(program_test_context::ProgramTestError::Program)?;
 
     program_test_context::process_instruction_with_signer(
         program_test_context,

--- a/programs/uxd/tests/integration_tests/api/program_test_context/process_instruction.rs
+++ b/programs/uxd/tests/integration_tests/api/program_test_context/process_instruction.rs
@@ -15,7 +15,7 @@ async fn process_instruction_result(
     program_test_context.last_blockhash = program_test_context
         .get_new_latest_blockhash()
         .await
-        .map_err(|e| program_test_context::ProgramTestError::IoError(e))?;
+        .map_err(program_test_context::ProgramTestError::Io)?;
     // Log the result, useful for debugging as STDOUT is displayed when a test fails
     println!(" -------- PROCESSING INSTRUCTION --------");
     println!(
@@ -40,7 +40,7 @@ pub async fn process_instruction(
         .banks_client
         .process_transaction(transaction)
         .await
-        .map_err(|e| program_test_context::ProgramTestError::BanksClientError(e));
+        .map_err(program_test_context::ProgramTestError::BanksClient);
     process_instruction_result(program_test_context, instruction.clone(), result).await
 }
 
@@ -57,6 +57,6 @@ pub async fn process_instruction_with_signer(
         .banks_client
         .process_transaction(transaction)
         .await
-        .map_err(|e| program_test_context::ProgramTestError::BanksClientError(e));
+        .map_err(program_test_context::ProgramTestError::BanksClient);
     process_instruction_result(program_test_context, instruction.clone(), result).await
 }

--- a/programs/uxd/tests/integration_tests/api/program_test_context/program_test_error.rs
+++ b/programs/uxd/tests/integration_tests/api/program_test_context/program_test_error.rs
@@ -3,10 +3,10 @@ use solana_program_test::BanksClientError;
 
 #[derive(Debug)]
 pub enum ProgramTestError {
-    BanksClientError(BanksClientError),
-    SignatureError(String),
-    ProgramError(ProgramError),
-    AnchorError(anchor_lang::error::Error),
-    IoError(std::io::Error),
-    CustomError(&'static str),
+    BanksClient(BanksClientError),
+    Signature(String),
+    Program(ProgramError),
+    Anchor(anchor_lang::error::Error),
+    Io(std::io::Error),
+    Custom(&'static str),
 }

--- a/programs/uxd/tests/integration_tests/api/program_test_context/read_account.rs
+++ b/programs/uxd/tests/integration_tests/api/program_test_context/read_account.rs
@@ -14,8 +14,8 @@ pub async fn read_account_data(
         .banks_client
         .get_account(*address)
         .await
-        .map_err(|e| program_test_context::ProgramTestError::BanksClientError(e))?
-        .ok_or(program_test_context::ProgramTestError::CustomError(
+        .map_err(program_test_context::ProgramTestError::BanksClient)?
+        .ok_or(program_test_context::ProgramTestError::Custom(
             "AccountDoesNotExist",
         ))?;
     Ok(raw_account.data)
@@ -29,7 +29,7 @@ pub async fn read_account_anchor<T: AccountDeserialize>(
         program_test_context::read_account_data(program_test_context, address).await?;
     let mut raw_account_slice: &[u8] = &raw_account_data;
     T::try_deserialize(&mut raw_account_slice)
-        .map_err(|e| program_test_context::ProgramTestError::AnchorError(e))
+        .map_err(program_test_context::ProgramTestError::Anchor)
 }
 
 pub async fn read_account_packed<T: Pack + IsInitialized>(
@@ -38,7 +38,6 @@ pub async fn read_account_packed<T: Pack + IsInitialized>(
 ) -> Result<T, program_test_context::ProgramTestError> {
     let raw_account_data =
         program_test_context::read_account_data(program_test_context, address).await?;
-    let mut raw_account_slice: &[u8] = &raw_account_data;
-    T::unpack(&mut raw_account_slice)
-        .map_err(|e| program_test_context::ProgramTestError::ProgramError(e))
+    let raw_account_slice: &[u8] = &raw_account_data;
+    T::unpack(raw_account_slice).map_err(program_test_context::ProgramTestError::Program)
 }

--- a/programs/uxd/tests/integration_tests/api/program_uxd/accounts/create_identity_depository_keys.rs
+++ b/programs/uxd/tests/integration_tests/api/program_uxd/accounts/create_identity_depository_keys.rs
@@ -7,13 +7,11 @@ pub struct IdentityDepositoryKeys {
 
 pub fn create_identity_depository_keys() -> IdentityDepositoryKeys {
     let depository =
-        Pubkey::find_program_address(&[uxd::IDENTITY_DEPOSITORY_NAMESPACE.as_ref()], &uxd::id()).0;
+        Pubkey::find_program_address(&[uxd::IDENTITY_DEPOSITORY_NAMESPACE], &uxd::id()).0;
 
-    let collateral_vault = Pubkey::find_program_address(
-        &[uxd::IDENTITY_DEPOSITORY_COLLATERAL_NAMESPACE.as_ref()],
-        &uxd::id(),
-    )
-    .0;
+    let collateral_vault =
+        Pubkey::find_program_address(&[uxd::IDENTITY_DEPOSITORY_COLLATERAL_NAMESPACE], &uxd::id())
+            .0;
 
     IdentityDepositoryKeys {
         depository,

--- a/programs/uxd/tests/integration_tests/api/program_uxd/accounts/create_program_keys.rs
+++ b/programs/uxd/tests/integration_tests/api/program_uxd/accounts/create_program_keys.rs
@@ -18,11 +18,10 @@ pub fn create_program_keys() -> ProgramKeys {
     let collateral_authority = Keypair::new();
     let collateral_mint = Keypair::new();
 
-    let controller =
-        Pubkey::find_program_address(&[uxd::CONTROLLER_NAMESPACE.as_ref()], &uxd::id()).0;
+    let controller = Pubkey::find_program_address(&[uxd::CONTROLLER_NAMESPACE], &uxd::id()).0;
 
     let redeemable_mint =
-        Pubkey::find_program_address(&[uxd::REDEEMABLE_MINT_NAMESPACE.as_ref()], &uxd::id()).0;
+        Pubkey::find_program_address(&[uxd::REDEEMABLE_MINT_NAMESPACE], &uxd::id()).0;
 
     let identity_depository_keys = program_uxd::accounts::create_identity_depository_keys();
 

--- a/programs/uxd/tests/integration_tests/api/program_uxd/procedures/process_deploy_program.rs
+++ b/programs/uxd/tests/integration_tests/api/program_uxd/procedures/process_deploy_program.rs
@@ -22,7 +22,7 @@ pub async fn process_deploy_program(
     // Create the collateral mint
     program_spl::instructions::process_token_mint_init(
         program_test_context,
-        &payer,
+        payer,
         &program_keys.collateral_mint,
         redeemable_mint_decimals,
         &program_keys.collateral_authority.pubkey(),

--- a/programs/uxd/tests/unit_tests/utils/math/checked_add_u128_and_i128.rs
+++ b/programs/uxd/tests/unit_tests/utils/math/checked_add_u128_and_i128.rs
@@ -42,8 +42,8 @@ mod test_compute_amount_after_change {
 
     #[test]
     fn test_incorrectness() -> Result<()> {
-        assert_eq!(checked_add_u128_and_i128(0, -1).is_err(), true);
-        assert_eq!(checked_add_u128_and_i128(u128::MAX, 1).is_err(), true);
+        assert!(checked_add_u128_and_i128(0, -1).is_err());
+        assert!(checked_add_u128_and_i128(u128::MAX, 1).is_err());
         Ok(())
     }
 
@@ -70,12 +70,11 @@ mod test_compute_amount_after_change {
             }
             // Otherwise When its a decrease
             if change_delta < 0 {
-                let decrease: u128;
-                if change_delta == i128::MIN {
-                    decrease = u128::try_from(u128::MAX).unwrap() + 1;
+                let decrease: u128 = if change_delta == i128::MIN {
+                    u128::try_from(i128::MAX).unwrap() + 1
                 } else {
-                    decrease = u128::try_from(-change_delta).unwrap();
-                }
+                    u128::try_from(-change_delta).unwrap()
+                };
                 // If the decrease is bigger than the amount, expect failure
                 if decrease > value_before {
                     prop_assert!(result.is_err());

--- a/programs/uxd/tests/unit_tests/utils/math/compute_amount_less_fraction.rs
+++ b/programs/uxd/tests/unit_tests/utils/math/compute_amount_less_fraction.rs
@@ -57,12 +57,12 @@ mod test_compute_amount_less_fraction {
 
     #[test]
     fn test_incorrectness() -> Result<()> {
-        assert_eq!(compute_amount_less_fraction(0, 0, 0).is_err(), true);
-        assert_eq!(compute_amount_less_fraction(0, 10, 0).is_err(), true);
-        assert_eq!(compute_amount_less_fraction(10, 0, 0).is_err(), true);
-        assert_eq!(compute_amount_less_fraction(10, 10, 0).is_err(), true);
+        assert!(compute_amount_less_fraction(0, 0, 0).is_err());
+        assert!(compute_amount_less_fraction(0, 10, 0).is_err());
+        assert!(compute_amount_less_fraction(10, 0, 0).is_err());
+        assert!(compute_amount_less_fraction(10, 10, 0).is_err());
 
-        assert_eq!(compute_amount_less_fraction(0, 101, 100).is_err(), true);
+        assert!(compute_amount_less_fraction(0, 101, 100).is_err());
         Ok(())
     }
 

--- a/programs/uxd/tests/unit_tests/utils/math/compute_decrease.rs
+++ b/programs/uxd/tests/unit_tests/utils/math/compute_decrease.rs
@@ -16,10 +16,10 @@ mod test_compute_decrease {
 
     #[test]
     fn test_increase() -> Result<()> {
-        assert_eq!(compute_decrease(0, 1).is_err(), true);
-        assert_eq!(compute_decrease(0, 1_000_000).is_err(), true);
-        assert_eq!(compute_decrease(5, 2_000_000).is_err(), true);
-        assert_eq!(compute_decrease(4_000_000, 5_000_000).is_err(), true);
+        assert!(compute_decrease(0, 1).is_err());
+        assert!(compute_decrease(0, 1_000_000).is_err());
+        assert!(compute_decrease(5, 2_000_000).is_err());
+        assert!(compute_decrease(4_000_000, 5_000_000).is_err());
         Ok(())
     }
 }

--- a/programs/uxd/tests/unit_tests/utils/math/compute_increase.rs
+++ b/programs/uxd/tests/unit_tests/utils/math/compute_increase.rs
@@ -6,10 +6,10 @@ mod test_compute_increase {
 
     #[test]
     fn test_decrease() -> Result<()> {
-        assert_eq!(compute_increase(1, 0).is_err(), true);
-        assert_eq!(compute_increase(1_000_000, 0).is_err(), true);
-        assert_eq!(compute_increase(2_000_000, 5).is_err(), true);
-        assert_eq!(compute_increase(5_000_000, 4_000_000).is_err(), true);
+        assert!(compute_increase(1, 0).is_err());
+        assert!(compute_increase(1_000_000, 0).is_err());
+        assert!(compute_increase(2_000_000, 5).is_err());
+        assert!(compute_increase(5_000_000, 4_000_000).is_err());
         Ok(())
     }
 

--- a/programs/uxd/tests/unit_tests/utils/math/compute_shares_amount_for_value.rs
+++ b/programs/uxd/tests/unit_tests/utils/math/compute_shares_amount_for_value.rs
@@ -53,9 +53,9 @@ mod test_compute_shares_amount_for_value {
 
     #[test]
     fn test_incorrectness() -> Result<()> {
-        assert_eq!(compute_shares_amount_for_value(1, 0, 0).is_err(), true);
-        assert_eq!(compute_shares_amount_for_value(1, 10, 0).is_err(), true);
-        assert_eq!(compute_shares_amount_for_value(1, 0, 10).is_err(), true);
+        assert!(compute_shares_amount_for_value(1, 0, 0).is_err());
+        assert!(compute_shares_amount_for_value(1, 10, 0).is_err());
+        assert!(compute_shares_amount_for_value(1, 0, 10).is_err());
         Ok(())
     }
 

--- a/programs/uxd/tests/unit_tests/utils/math/compute_value_for_shares_amount.rs
+++ b/programs/uxd/tests/unit_tests/utils/math/compute_value_for_shares_amount.rs
@@ -57,9 +57,9 @@ mod test_compute_value_for_shares_amount {
 
     #[test]
     fn test_incorrectness() -> Result<()> {
-        assert_eq!(compute_value_for_shares_amount(1, 0, 0).is_err(), true);
-        assert_eq!(compute_value_for_shares_amount(1, 0, 10).is_err(), true);
-        assert_eq!(compute_value_for_shares_amount(1, 10, 0).is_err(), true);
+        assert!(compute_value_for_shares_amount(1, 0, 0).is_err());
+        assert!(compute_value_for_shares_amount(1, 0, 10).is_err());
+        assert!(compute_value_for_shares_amount(1, 10, 0).is_err());
         Ok(())
     }
 

--- a/programs/uxd/tests/unit_tests/utils/math/compute_value_for_single_share_ceil.rs
+++ b/programs/uxd/tests/unit_tests/utils/math/compute_value_for_single_share_ceil.rs
@@ -27,17 +27,11 @@ mod test_compute_value_for_single_share_ceil {
 
     #[test]
     fn test_incorrectness() -> Result<()> {
-        assert_eq!(compute_value_for_single_share_ceil(0, 0).is_err(), true);
-        assert_eq!(compute_value_for_single_share_ceil(0, 1).is_err(), true);
-        assert_eq!(
-            compute_value_for_single_share_ceil(0, u64::MAX).is_err(),
-            true
-        );
-        assert_eq!(compute_value_for_single_share_ceil(1, 0).is_err(), true);
-        assert_eq!(
-            compute_value_for_single_share_ceil(u64::MAX, 0).is_err(),
-            true
-        );
+        assert!(compute_value_for_single_share_ceil(0, 0).is_err());
+        assert!(compute_value_for_single_share_ceil(0, 1).is_err());
+        assert!(compute_value_for_single_share_ceil(0, u64::MAX).is_err());
+        assert!(compute_value_for_single_share_ceil(1, 0).is_err());
+        assert!(compute_value_for_single_share_ceil(u64::MAX, 0).is_err());
         Ok(())
     }
 

--- a/programs/uxd/tests/unit_tests/utils/math/is_within_range_inclusive.rs
+++ b/programs/uxd/tests/unit_tests/utils/math/is_within_range_inclusive.rs
@@ -6,25 +6,25 @@ mod test_is_within_range_inclusive {
 
     #[test]
     fn test_equality() -> Result<()> {
-        assert_eq!(is_within_range_inclusive(0, 0, 1), true);
-        assert_eq!(is_within_range_inclusive(1, 0, 1), true);
-        assert_eq!(is_within_range_inclusive(1000, 0, 1000), true);
-        assert_eq!(is_within_range_inclusive(999, 0, 1000), true);
-        assert_eq!(is_within_range_inclusive(1, 0, 1000), true);
-        assert_eq!(is_within_range_inclusive(0, 0, 1000), true);
-        assert_eq!(is_within_range_inclusive(2000, 1000, 2000), true);
-        assert_eq!(is_within_range_inclusive(1999, 1000, 2000), true);
-        assert_eq!(is_within_range_inclusive(1001, 1000, 2000), true);
-        assert_eq!(is_within_range_inclusive(1000, 1000, 2000), true);
+        assert!(is_within_range_inclusive(0, 0, 1));
+        assert!(is_within_range_inclusive(1, 0, 1));
+        assert!(is_within_range_inclusive(1000, 0, 1000));
+        assert!(is_within_range_inclusive(999, 0, 1000));
+        assert!(is_within_range_inclusive(1, 0, 1000));
+        assert!(is_within_range_inclusive(0, 0, 1000));
+        assert!(is_within_range_inclusive(2000, 1000, 2000));
+        assert!(is_within_range_inclusive(1999, 1000, 2000));
+        assert!(is_within_range_inclusive(1001, 1000, 2000));
+        assert!(is_within_range_inclusive(1000, 1000, 2000));
         Ok(())
     }
 
     #[test]
     fn test_inequality() -> Result<()> {
-        assert_eq!(is_within_range_inclusive(2, 0, 1), false);
-        assert_eq!(is_within_range_inclusive(1001, 0, 1000), false);
-        assert_eq!(is_within_range_inclusive(2001, 1000, 2000), false);
-        assert_eq!(is_within_range_inclusive(999, 1000, 2000), false);
+        assert!(!is_within_range_inclusive(2, 0, 1));
+        assert!(!is_within_range_inclusive(1001, 0, 1000));
+        assert!(!is_within_range_inclusive(2001, 1000, 2000));
+        assert!(!is_within_range_inclusive(999, 1000, 2000));
         Ok(())
     }
 }


### PR DESCRIPTION
Greg did note that we were note using the `--all-targets` flag when using `cargo clippy`

This flags allows us to surface a bit more small coding mistakes, so this PR enables this flag and fix current problems.
