### PR TITLE
[Hotfix] Fix for maths error in credix rebalance redeem

### DIFF
--- a/programs/uxd/src/instructions/credix_lp/rebalance_redeem_withdraw_request_from_credix_lp_depository.rs
+++ b/programs/uxd/src/instructions/credix_lp/rebalance_redeem_withdraw_request_from_credix_lp_depository.rs
@@ -285,6 +285,10 @@ pub(crate) fn handler(
     let profits_collateral_amount = owned_shares_value_before
         .checked_sub(redeemable_amount_under_management)
         .ok_or(UxdError::MathError)?;
+    msg!(
+        "[rebalance_redeem_withdraw_request_from_credix_lp_depository:profits_collateral_amount:{}]",
+        profits_collateral_amount
+    );
 
     let overflow_value = {
         let redeemable_amount_under_management_target_amount =
@@ -302,6 +306,10 @@ pub(crate) fn handler(
                 .ok_or(UxdError::MathError)?
         }
     };
+    msg!(
+        "[rebalance_redeem_withdraw_request_from_credix_lp_depository:overflow_value:{}]",
+        overflow_value
+    );
 
     // ---------------------------------------------------------------------
     // -- Phase 4

--- a/programs/uxd/tests/integration_tests/suites/test_credix_lp_depository_rebalance_illiquid.rs
+++ b/programs/uxd/tests/integration_tests/suites/test_credix_lp_depository_rebalance_illiquid.rs
@@ -89,13 +89,15 @@ async fn test_credix_lp_depository_rebalance_illiquid(
         .await?;
 
     // Useful amounts used during testing scenario
-    let amount_we_use_as_supply_cap = ui_amount_to_native_amount(50, redeemable_mint_decimals);
+    let amount_we_use_as_supply_cap =
+        ui_amount_to_native_amount(50_000_000, redeemable_mint_decimals);
 
     let amount_of_collateral_airdropped_to_user =
-        ui_amount_to_native_amount(1000, collateral_mint_decimals);
+        ui_amount_to_native_amount(1_000_000_000, collateral_mint_decimals);
     let amount_the_user_should_be_able_to_mint =
-        ui_amount_to_native_amount(50, collateral_mint_decimals);
-    let amount_that_should_remain_liquid = ui_amount_to_native_amount(10, collateral_mint_decimals);
+        ui_amount_to_native_amount(50_000_000, collateral_mint_decimals);
+    let amount_that_should_remain_liquid =
+        ui_amount_to_native_amount(10_000_000, collateral_mint_decimals);
 
     // ---------------------------------------------------------------------
     // -- Phase 2

--- a/programs/uxd/tests/integration_tests/suites/test_credix_lp_depository_rebalance_liquid.rs
+++ b/programs/uxd/tests/integration_tests/suites/test_credix_lp_depository_rebalance_liquid.rs
@@ -88,12 +88,13 @@ async fn test_credix_lp_depository_rebalance_liquid(
         .await?;
 
     // Useful amounts used during testing scenario
-    let amount_we_use_as_supply_cap = ui_amount_to_native_amount(50, redeemable_mint_decimals);
+    let amount_we_use_as_supply_cap =
+        ui_amount_to_native_amount(50_000_000, redeemable_mint_decimals);
 
     let amount_of_collateral_airdropped_to_user =
-        ui_amount_to_native_amount(1000, collateral_mint_decimals);
+        ui_amount_to_native_amount(1_000_000_000, collateral_mint_decimals);
     let amount_the_user_should_be_able_to_mint =
-        ui_amount_to_native_amount(50, collateral_mint_decimals);
+        ui_amount_to_native_amount(50_000_000, collateral_mint_decimals);
 
     // ---------------------------------------------------------------------
     // -- Phase 2

--- a/scripts/trigger_rebalance_credix.js
+++ b/scripts/trigger_rebalance_credix.js
@@ -316,7 +316,7 @@ async function main() {
     );
   console.log('> credixWithdrawRequestAccount');
   console.log(
-    'credixWithdrawRequestAccount.baseAmount',
+    'credixWithdrawRequestAccount.baseAmount(requested)',
     nativeToUi(credixWithdrawRequestAccount.baseAmount, credixBaseDecimals)
   );
   console.log(
@@ -330,6 +330,16 @@ async function main() {
     'credixWithdrawRequestAccount.investorTotalLpAmount',
     nativeToUi(
       credixWithdrawRequestAccount.investorTotalLpAmount,
+      credixBaseDecimals
+    )
+  );
+  console.log(
+    'credixWithdrawRequestAccount.baseAmountWithdrawable(computed)',
+    nativeToUi(
+      credixGlobalMarketStateAccount.lockedLiquidity
+        .mul(credixWithdrawRequestAccount.investorTotalLpAmount)
+        .div(credixWithdrawEpochAccount.participatingInvestorsTotalLpAmount)
+        .sub(credixWithdrawRequestAccount.baseAmountWithdrawn),
       credixBaseDecimals
     )
   );


### PR DESCRIPTION
Accidentally used `checked_mul(u64)` function from 2 `u64` numbers, which can result into a u64 overflow if the numbers are huge.

Here this can just be fixed by using `u128` for intermediary maths logic, even if the resulting value is in `u64`