### PR TITLE
[Credix] Fixing precision loss maths for no-overflow case

### DIFF
--- a/programs/uxd/src/instructions/credix_lp/rebalance_redeem_withdraw_request_from_credix_lp_depository.rs
+++ b/programs/uxd/src/instructions/credix_lp/rebalance_redeem_withdraw_request_from_credix_lp_depository.rs
@@ -394,23 +394,13 @@ pub(crate) fn handler(
             total_shares_value_before,
         )?;
 
-    let withdrawal_precision_loss = withdrawal_total_collateral_amount
-        .checked_sub(withdrawal_total_collateral_amount_after_precision_loss)
-        .ok_or(UxdError::MathError)?;
-
-    let withdrawal_profits_collateral_amount_after_precision_loss = std::cmp::min(
-        withdrawal_total_collateral_amount_after_precision_loss,
-        withdrawal_profits_collateral_amount,
-    )
-    .checked_sub(withdrawal_precision_loss)
-    .ok_or(UxdError::MathError)?; // The precision loss is taken from the profits, to avoid impacting the redeemable backing
-
-    let withdrawal_overflow_value_after_precision_loss = std::cmp::min(
+    // Precision loss should be taken from the profits, not the overflow
+    // Otherwise this means that the precision loss would take out of the backing value
+    let withdrawal_overflow_value_after_precision_loss = withdrawal_overflow_value;
+    let withdrawal_profits_collateral_amount_after_precision_loss =
         withdrawal_total_collateral_amount_after_precision_loss
-            .checked_sub(withdrawal_profits_collateral_amount_after_precision_loss)
-            .ok_or(UxdError::MathError)?,
-        withdrawal_overflow_value,
-    );
+            .checked_sub(withdrawal_overflow_value_after_precision_loss)
+            .ok_or(UxdError::MathError)?;
 
     // ---------------------------------------------------------------------
     // -- Phase 6

--- a/programs/uxd/tests/integration_tests/suites/mod.rs
+++ b/programs/uxd/tests/integration_tests/suites/mod.rs
@@ -3,6 +3,7 @@ pub mod test_credix_lp_depository_edit;
 pub mod test_credix_lp_depository_mint;
 pub mod test_credix_lp_depository_rebalance_illiquid;
 pub mod test_credix_lp_depository_rebalance_liquid;
+pub mod test_credix_lp_depository_rebalance_no_overflow;
 pub mod test_identity_depository_edit;
 pub mod test_identity_depository_mint_and_redeem;
 pub mod test_mercurial_vault_depository_edit;

--- a/programs/uxd/tests/integration_tests/suites/test_credix_lp_depository_rebalance_no_overflow.rs
+++ b/programs/uxd/tests/integration_tests/suites/test_credix_lp_depository_rebalance_no_overflow.rs
@@ -1,0 +1,246 @@
+use solana_program_test::tokio;
+use solana_sdk::signer::keypair::Keypair;
+use solana_sdk::signer::Signer;
+
+use uxd::instructions::EditControllerFields;
+use uxd::instructions::EditCredixLpDepositoryFields;
+use uxd::instructions::EditDepositoriesRoutingWeightBps;
+use uxd::instructions::EditIdentityDepositoryFields;
+use uxd::instructions::EditMercurialVaultDepositoryFields;
+
+use crate::integration_tests::api::program_credix;
+use crate::integration_tests::api::program_spl;
+use crate::integration_tests::api::program_test_context;
+use crate::integration_tests::api::program_uxd;
+use crate::integration_tests::utils::ui_amount_to_native_amount;
+
+#[tokio::test]
+async fn test_credix_lp_depository_rebalance_no_overflow(
+) -> Result<(), program_test_context::ProgramTestError> {
+    // ---------------------------------------------------------------------
+    // -- Phase 1
+    // -- Setup basic context and accounts needed for this test suite
+    // ---------------------------------------------------------------------
+
+    let mut program_test_context = program_test_context::create_program_test_context().await;
+
+    // Fund payer
+    let payer = Keypair::new();
+    program_spl::instructions::process_lamports_airdrop(
+        &mut program_test_context,
+        &payer.pubkey(),
+        1_000_000_000_000,
+    )
+    .await?;
+
+    // Hardcode mints decimals
+    let collateral_mint_decimals = 6;
+    let redeemable_mint_decimals = 6;
+
+    // Important account keys
+    let authority = Keypair::new();
+    let collateral_mint = Keypair::new();
+    let mercurial_vault_lp_mint = Keypair::new();
+    let credix_multisig = Keypair::new();
+
+    // Initialize basic UXD program state
+    program_uxd::procedures::process_deploy_program(
+        &mut program_test_context,
+        &payer,
+        &authority,
+        &collateral_mint,
+        &mercurial_vault_lp_mint,
+        &credix_multisig,
+        collateral_mint_decimals,
+        redeemable_mint_decimals,
+    )
+    .await?;
+
+    // Main actor
+    let user = Keypair::new();
+    let profits_beneficiary = Keypair::new();
+
+    // Create a collateral account for our user
+    let user_collateral = program_spl::instructions::process_associated_token_account_get_or_init(
+        &mut program_test_context,
+        &payer,
+        &collateral_mint.pubkey(),
+        &user.pubkey(),
+    )
+    .await?;
+    // Create a redeemable account for our user
+    let user_redeemable = program_spl::instructions::process_associated_token_account_get_or_init(
+        &mut program_test_context,
+        &payer,
+        &program_uxd::accounts::find_redeemable_mint_pda().0,
+        &user.pubkey(),
+    )
+    .await?;
+
+    // Create a collateral account for our profits_beneficiary
+    let profits_beneficiary_collateral =
+        program_spl::instructions::process_associated_token_account_get_or_init(
+            &mut program_test_context,
+            &payer,
+            &collateral_mint.pubkey(),
+            &profits_beneficiary.pubkey(),
+        )
+        .await?;
+
+    // Useful amounts used during testing scenario
+    let amount_we_use_as_supply_cap =
+        ui_amount_to_native_amount(50_000_000, redeemable_mint_decimals);
+
+    let amount_of_collateral_airdropped_to_user =
+        ui_amount_to_native_amount(1_000_000_000, collateral_mint_decimals);
+    let amount_the_user_should_be_able_to_mint =
+        ui_amount_to_native_amount(50_000_000, collateral_mint_decimals);
+
+    // ---------------------------------------------------------------------
+    // -- Phase 2
+    // -- Prepare the program state to be ready,
+    // -- Mint a bunch using credix to fill it up above its target
+    // ---------------------------------------------------------------------
+
+    // Airdrop collateral to our user
+    program_spl::instructions::process_token_mint_to(
+        &mut program_test_context,
+        &payer,
+        &collateral_mint.pubkey(),
+        &collateral_mint,
+        &user_collateral,
+        amount_of_collateral_airdropped_to_user,
+    )
+    .await?;
+
+    // Set the controller cap and the weights
+    program_uxd::instructions::process_edit_controller(
+        &mut program_test_context,
+        &payer,
+        &authority,
+        &EditControllerFields {
+            redeemable_global_supply_cap: Some(amount_we_use_as_supply_cap.into()),
+            depositories_routing_weight_bps: Some(EditDepositoriesRoutingWeightBps {
+                identity_depository_weight_bps: 0,
+                mercurial_vault_depository_weight_bps: 0,
+                credix_lp_depository_weight_bps: 100 * 100,
+            }),
+            router_depositories: None,
+        },
+    )
+    .await?;
+
+    // Now we set the router depositories to the correct PDAs
+    program_uxd::procedures::process_set_router_depositories(
+        &mut program_test_context,
+        &payer,
+        &authority,
+        &collateral_mint.pubkey(),
+    )
+    .await?;
+
+    // Set the identity_depository cap and make sure minting is not disabled
+    program_uxd::instructions::process_edit_identity_depository(
+        &mut program_test_context,
+        &payer,
+        &authority,
+        &EditIdentityDepositoryFields {
+            redeemable_amount_under_management_cap: Some(amount_we_use_as_supply_cap.into()),
+            minting_disabled: Some(false),
+        },
+    )
+    .await?;
+
+    // Set the mercurial_vault_depository cap and make sure minting is not disabled
+    program_uxd::instructions::process_edit_mercurial_vault_depository(
+        &mut program_test_context,
+        &payer,
+        &authority,
+        &collateral_mint.pubkey(),
+        &EditMercurialVaultDepositoryFields {
+            redeemable_amount_under_management_cap: Some(amount_we_use_as_supply_cap.into()),
+            minting_fee_in_bps: Some(100),
+            redeeming_fee_in_bps: Some(100),
+            minting_disabled: Some(false),
+            profits_beneficiary_collateral: Some(profits_beneficiary_collateral),
+        },
+    )
+    .await?;
+
+    // Set the credix_lp_depository cap and make sure minting is not disabled
+    program_uxd::instructions::process_edit_credix_lp_depository(
+        &mut program_test_context,
+        &payer,
+        &authority,
+        &collateral_mint.pubkey(),
+        &EditCredixLpDepositoryFields {
+            redeemable_amount_under_management_cap: Some(amount_we_use_as_supply_cap.into()),
+            minting_fee_in_bps: Some(100),
+            redeeming_fee_in_bps: Some(100),
+            minting_disabled: Some(false),
+            profits_beneficiary_collateral: Some(profits_beneficiary_collateral),
+        },
+    )
+    .await?;
+
+    // Minting on credix should work now that everything is set
+    program_uxd::instructions::process_mint_with_credix_lp_depository(
+        &mut program_test_context,
+        &payer,
+        &collateral_mint.pubkey(),
+        &user,
+        &user_collateral,
+        &user_redeemable,
+        amount_the_user_should_be_able_to_mint,
+    )
+    .await?;
+
+    // ---------------------------------------------------------------------
+    // -- Phase 2
+    // -- Do a complete rebalance, but no overflow should be needed, only profits
+    // ---------------------------------------------------------------------
+
+    // Create an epoch (done by credix team usually)
+    program_credix::instructions::process_create_withdraw_epoch(
+        &mut program_test_context,
+        &credix_multisig,
+        1,
+    )
+    .await?;
+
+    // Since the epoch was just created it should be available to create a WithdrawRequest
+    program_uxd::instructions::process_rebalance_create_withdraw_request_from_credix_lp_depository(
+        &mut program_test_context,
+        &payer,
+        &collateral_mint.pubkey(),
+    )
+    .await?;
+
+    // Pretend 3 days have passed (the time for the request period)
+    program_test_context::move_clock_forward(&mut program_test_context, 3 * 24 * 60 * 60).await?;
+
+    // Set the epoch's locked liquidity (done by credix team usually)
+    program_credix::instructions::process_set_locked_liquidity(
+        &mut program_test_context,
+        &credix_multisig,
+        &collateral_mint.pubkey(),
+    )
+    .await?;
+
+    // Executing the rebalance request should now work as intended because we are in the execute period
+    let expected_credix_profits = amount_the_user_should_be_able_to_mint / 100; // minting fees 1%
+    program_uxd::instructions::process_rebalance_redeem_withdraw_request_from_credix_lp_depository(
+        &mut program_test_context,
+        &payer,
+        &collateral_mint.pubkey(),
+        &credix_multisig.pubkey(),
+        &profits_beneficiary_collateral,
+        0, // No overflow, no need to withdraw anything
+        expected_credix_profits // Profits should be withdrawn
+         - 1, // Precision loss expected to be taken out of the profits
+    )
+    .await?;
+
+    // Done
+    Ok(())
+}

--- a/scripts/trigger_rebalance_credix.js
+++ b/scripts/trigger_rebalance_credix.js
@@ -5,6 +5,8 @@ const {
   MercurialVaultDepository,
   UXDClient,
   nativeToUi,
+  uiToNative,
+  CredixLpDepositoryAccount,
 } = require('@uxd-protocol/uxd-client');
 const {
   Connection,
@@ -14,6 +16,7 @@ const {
   ComputeBudgetProgram,
 } = require('@solana/web3.js');
 const { web3 } = require('@project-serum/anchor');
+const { BN } = require('bn.js');
 
 const TXN_COMMIT = 'confirmed';
 const connectionConfig = {
@@ -105,9 +108,17 @@ async function main() {
   mercurialVaultDepository.info();
   credixLpDepository.info();
 
-  const profitsBeneficiaryCollateral = (
-    await credixLpDepository.getOnchainAccount(getConnection(), TXN_OPTS)
-  ).profitsBeneficiaryCollateral;
+  const controllerAccount = await controller.getOnchainAccount(
+    getConnection(),
+    TXN_OPTS
+  );
+  const credixLpDepositoryAccount = await credixLpDepository.getOnchainAccount(
+    getConnection(),
+    TXN_OPTS
+  );
+
+  const profitsBeneficiaryCollateral =
+    credixLpDepositoryAccount.profitsBeneficiaryCollateral;
   console.log(
     'profitsBeneficiaryCollateral',
     profitsBeneficiaryCollateral.toBase58()
@@ -139,6 +150,7 @@ async function main() {
   );
   rebalanceCreateTransaction.feePayer = payer.publicKey;
 
+  /*
   try {
     const rebalanceCreateResult = await web3.sendAndConfirmTransaction(
       getConnection(),
@@ -150,6 +162,7 @@ async function main() {
   } catch (rebalanceCreateError) {
     console.log('rebalanceCreateError', rebalanceCreateError);
   }
+  */
 
   console.log();
   console.log('------------------------------ ------------------------------');
@@ -176,6 +189,7 @@ async function main() {
   );
   rebalanceRedeemTransaction.feePayer = payer.publicKey;
 
+  /*
   try {
     const rebalanceRedeemResult = await web3.sendAndConfirmTransaction(
       getConnection(),
@@ -187,6 +201,7 @@ async function main() {
   } catch (rebalanceRedeemError) {
     console.log('rebalanceRedeemError', rebalanceRedeemError);
   }
+  */
 
   console.log();
   console.log('------------------------------ ------------------------------');
@@ -355,6 +370,219 @@ async function main() {
     )
   );
   console.log();
+
+  const credixSharesMintAccount = await getConnection().getTokenSupply(
+    credixLpDepository.credixSharesMint
+  );
+  console.log('> credixSharesMint');
+  console.log(
+    'credixSharesMint.supply',
+    credixSharesMintAccount.value.uiAmount
+  );
+  console.log();
+
+  const credixLiquidityCollateralAccount =
+    await getConnection().getTokenAccountBalance(
+      credixLpDepository.credixLiquidityCollateral
+    );
+  console.log('> credixLiquidityCollateral');
+  console.log(
+    'credixLiquidityCollateral.amount',
+    credixLiquidityCollateralAccount.value.uiAmount
+  );
+  console.log();
+
+  const depositoryCollateralAccount =
+    await getConnection().getTokenAccountBalance(
+      credixLpDepository.depositoryCollateral
+    );
+  console.log('> depositoryCollateral');
+  console.log(
+    'depositoryCollateral.amount',
+    depositoryCollateralAccount.value.uiAmount
+  );
+  console.log();
+
+  const depositorySharesAccount = await getConnection().getTokenAccountBalance(
+    credixLpDepository.depositoryShares
+  );
+  console.log('> depositoryShares');
+  console.log(
+    'depositoryShares.amount',
+    depositorySharesAccount.value.uiAmount
+  );
+  console.log();
+
+  console.log();
+  console.log('------------------------------ ------------------------------');
+  console.log('------------------ REBALANCING ESTIMATIONS ------------------');
+  console.log('------------------------------ ------------------------------');
+  console.log();
+
+  const total_shares_supply_before = new BN(
+    credixSharesMintAccount.value.amount
+  );
+  console.log(
+    '> total_shares_supply_before:',
+    total_shares_supply_before.toString()
+  );
+
+  const total_shares_value_before = new BN(
+    credixLiquidityCollateralAccount.value.amount
+  ).add(credixGlobalMarketStateAccount.poolOutstandingCredit);
+  console.log(
+    '> total_shares_value_before:',
+    total_shares_value_before.toString()
+  );
+
+  const owned_shares_amount_before = new BN(
+    depositorySharesAccount.value.amount
+  );
+  console.log(
+    '> owned_shares_amount_before:',
+    owned_shares_amount_before.toString()
+  );
+
+  const owned_shares_value_before = compute_value_for_shares_amount_floor(
+    owned_shares_amount_before,
+    total_shares_supply_before,
+    total_shares_value_before
+  );
+  console.log(
+    '> owned_shares_value_before:',
+    owned_shares_value_before.toString()
+  );
+
+  const redeemable_amount_under_management =
+    credixLpDepositoryAccount.redeemableAmountUnderManagement;
+  console.log(
+    '> redeemable_amount_under_management:',
+    redeemable_amount_under_management.toString()
+  );
+
+  const profits_collateral_amount = owned_shares_value_before.sub(
+    redeemable_amount_under_management
+  );
+  console.log(
+    '> profits_collateral_amount:',
+    profits_collateral_amount.toString()
+  );
+
+  const redeemable_amount_under_management_target_amount =
+    controllerAccount.redeemableCirculatingSupply
+      .muln(controllerAccount.credixLpDepositoryWeightBps)
+      .divn(10_000);
+  let overflow_value = redeemable_amount_under_management.sub(
+    redeemable_amount_under_management_target_amount
+  );
+  if (overflow_value < 0) {
+    overflow_value = new BN(0);
+  }
+  console.log('> overflow_value:', overflow_value.toString());
+
+  const withdrawable_total_collateral_amount =
+    credixGlobalMarketStateAccount.lockedLiquidity
+      .mul(credixWithdrawRequestAccount.investorTotalLpAmount)
+      .div(credixWithdrawEpochAccount.participatingInvestorsTotalLpAmount)
+      .sub(credixWithdrawRequestAccount.baseAmountWithdrawn);
+  console.log(
+    '> withdrawable_total_collateral_amount:',
+    withdrawable_total_collateral_amount.toString()
+  );
+
+  const withdrawal_profits_collateral_amount = BN.min(
+    withdrawable_total_collateral_amount,
+    profits_collateral_amount
+  );
+  console.log(
+    '> withdrawal_profits_collateral_amount:',
+    withdrawal_profits_collateral_amount.toString()
+  );
+
+  const withdrawal_overflow_value = BN.min(
+    withdrawable_total_collateral_amount.sub(
+      withdrawal_profits_collateral_amount
+    ),
+    overflow_value
+  );
+  console.log(
+    '> withdrawal_overflow_value:',
+    withdrawal_overflow_value.toString()
+  );
+
+  const withdrawal_total_collateral_amount =
+    withdrawal_profits_collateral_amount.add(withdrawal_overflow_value);
+  console.log(
+    '> withdrawal_total_collateral_amount:',
+    withdrawal_total_collateral_amount.toString()
+  );
+
+  const withdrawal_total_shares_amount = compute_shares_amount_for_value_floor(
+    withdrawal_total_collateral_amount,
+    total_shares_supply_before,
+    total_shares_value_before
+  );
+  console.log(
+    '> withdrawal_total_shares_amount:',
+    withdrawal_total_shares_amount.toString()
+  );
+
+  const withdrawal_total_collateral_amount_after_precision_loss =
+    compute_value_for_shares_amount_floor(
+      withdrawal_total_shares_amount,
+      total_shares_supply_before,
+      total_shares_value_before
+    );
+  console.log(
+    '> withdrawal_total_collateral_amount_after_precision_loss:',
+    withdrawal_total_collateral_amount_after_precision_loss.toString()
+  );
+
+  const withdrawal_precision_loss = withdrawal_total_collateral_amount.sub(
+    withdrawal_total_collateral_amount_after_precision_loss
+  );
+  console.log(
+    '> withdrawal_precision_loss:',
+    withdrawal_precision_loss.toString()
+  );
+
+  const withdrawal_profits_collateral_amount_after_precision_loss = BN.min(
+    withdrawal_total_collateral_amount_after_precision_loss,
+    withdrawal_profits_collateral_amount
+  ).sub(withdrawal_precision_loss);
+  console.log(
+    '> withdrawal_profits_collateral_amount_after_precision_loss:',
+    withdrawal_profits_collateral_amount_after_precision_loss.toString()
+  );
+
+  let withdrawal_overflow_value_after_precision_loss = BN.min(
+    withdrawal_total_collateral_amount_after_precision_loss.sub(
+      withdrawal_profits_collateral_amount_after_precision_loss
+    ),
+    withdrawal_overflow_value
+  );
+  console.log(
+    '> withdrawal_overflow_value_after_precision_loss:',
+    withdrawal_overflow_value_after_precision_loss.toString()
+  );
+
+  console.log();
+}
+
+function compute_value_for_shares_amount_floor(
+  shares_amount,
+  total_shares_supply,
+  total_shares_value
+) {
+  return shares_amount.mul(total_shares_value).div(total_shares_supply);
+}
+
+function compute_shares_amount_for_value_floor(
+  value,
+  total_shares_supply,
+  total_shares_value
+) {
+  return value.mul(total_shares_supply).div(total_shares_value);
 }
 
 main();

--- a/scripts/trigger_rebalance_credix.js
+++ b/scripts/trigger_rebalance_credix.js
@@ -538,32 +538,20 @@ async function main() {
     withdrawal_total_collateral_amount_after_precision_loss.toString()
   );
 
-  const withdrawal_precision_loss = withdrawal_total_collateral_amount.sub(
-    withdrawal_total_collateral_amount_after_precision_loss
-  );
-  console.log(
-    '> withdrawal_precision_loss:',
-    withdrawal_precision_loss.toString()
-  );
-
-  const withdrawal_profits_collateral_amount_after_precision_loss = BN.min(
-    withdrawal_total_collateral_amount_after_precision_loss,
-    withdrawal_profits_collateral_amount
-  ).sub(withdrawal_precision_loss);
-  console.log(
-    '> withdrawal_profits_collateral_amount_after_precision_loss:',
-    withdrawal_profits_collateral_amount_after_precision_loss.toString()
-  );
-
-  let withdrawal_overflow_value_after_precision_loss = BN.min(
-    withdrawal_total_collateral_amount_after_precision_loss.sub(
-      withdrawal_profits_collateral_amount_after_precision_loss
-    ),
-    withdrawal_overflow_value
-  );
+  let withdrawal_overflow_value_after_precision_loss =
+    withdrawal_overflow_value; // Precision loss should be taken from the profits, not the overflow
   console.log(
     '> withdrawal_overflow_value_after_precision_loss:',
     withdrawal_overflow_value_after_precision_loss.toString()
+  );
+
+  let withdrawal_profits_collateral_amount_after_precision_loss =
+    withdrawal_total_collateral_amount_after_precision_loss.sub(
+      withdrawal_overflow_value_after_precision_loss
+    );
+  console.log(
+    '> withdrawal_profits_collateral_amount_after_precision_loss:',
+    withdrawal_profits_collateral_amount_after_precision_loss.toString()
   );
 
   console.log();

--- a/scripts/trigger_rebalance_credix.js
+++ b/scripts/trigger_rebalance_credix.js
@@ -150,7 +150,6 @@ async function main() {
   );
   rebalanceCreateTransaction.feePayer = payer.publicKey;
 
-  /*
   try {
     const rebalanceCreateResult = await web3.sendAndConfirmTransaction(
       getConnection(),
@@ -162,7 +161,6 @@ async function main() {
   } catch (rebalanceCreateError) {
     console.log('rebalanceCreateError', rebalanceCreateError);
   }
-  */
 
   console.log();
   console.log('------------------------------ ------------------------------');
@@ -189,7 +187,6 @@ async function main() {
   );
   rebalanceRedeemTransaction.feePayer = payer.publicKey;
 
-  /*
   try {
     const rebalanceRedeemResult = await web3.sendAndConfirmTransaction(
       getConnection(),
@@ -201,7 +198,6 @@ async function main() {
   } catch (rebalanceRedeemError) {
     console.log('rebalanceRedeemError', rebalanceRedeemError);
   }
-  */
 
   console.log();
   console.log('------------------------------ ------------------------------');
@@ -415,7 +411,7 @@ async function main() {
 
   console.log();
   console.log('------------------------------ ------------------------------');
-  console.log('------------------ REBALANCING ESTIMATIONS ------------------');
+  console.log('----------------- REBALANCING REDEEM MATHS ------------------');
   console.log('------------------------------ ------------------------------');
   console.log();
 

--- a/scripts/trigger_rebalance_credix.js
+++ b/scripts/trigger_rebalance_credix.js
@@ -11,6 +11,7 @@ const {
   Keypair,
   PublicKey,
   Transaction,
+  ComputeBudgetProgram,
 } = require('@solana/web3.js');
 const { web3 } = require('@project-serum/anchor');
 
@@ -131,6 +132,11 @@ async function main() {
     );
   const rebalanceCreateTransaction = new Transaction();
   rebalanceCreateTransaction.add(rebalanceCreateInstruction);
+  rebalanceCreateTransaction.add(
+    ComputeBudgetProgram.setComputeUnitLimit({
+      units: 400_000,
+    })
+  );
   rebalanceCreateTransaction.feePayer = payer.publicKey;
 
   try {
@@ -163,6 +169,11 @@ async function main() {
     );
   const rebalanceRedeemTransaction = new Transaction();
   rebalanceRedeemTransaction.add(rebalanceRedeemInstruction);
+  rebalanceRedeemTransaction.add(
+    ComputeBudgetProgram.setComputeUnitLimit({
+      units: 400_000,
+    })
+  );
   rebalanceRedeemTransaction.feePayer = payer.publicKey;
 
   try {


### PR DESCRIPTION
There seems to be a bug in a very specific case:
- If the credix depository has NO OVERFLOW
- Aka if the depository has too much deposit compared to its target
- then the precision loss maths fails to redirect the precision loss from the profits to the overflow
- This means that 1 native unit remains untransfered and it triggers the safety assertions

Notes: 
- when credix is overweight (which is most of the time since its an illiquid protocol) then this problem does not exist.
- The rebalancing worked as of today (07/07/23) since credix was overweight today, so no emergency
- I added a test that reproduce this issue in the rust integration tests
