### PR TITLE
[Controller] Remove the need to register depositories

### DIFF
--- a/.github/workflows/ci-cargo-audit.yml
+++ b/.github/workflows/ci-cargo-audit.yml
@@ -35,10 +35,14 @@ jobs:
         # - RUSTSEC-2020-0071 -> No fixes available, ignored by solana-labs: https://github.com/solana-labs/solana/blob/master/ci/do-audit.sh
         # - RUSTSEC-2022-0093 -> No fixes available, ignored by solana-labs: https://github.com/solana-labs/solana/blob/master/ci/do-audit.sh
         # - RUSTSEC-2023-0001 -> No fixes available, ignored by solana-labs: https://github.com/solana-labs/solana/blob/master/ci/do-audit.sh
+        # - RUSTSEC-2023-0052 -> Fixed by upgrading to v1.16 solana, ignored by solana-labs before v1.16: https://github.com/solana-labs/solana/issues/32933
         # - RUSTSEC-2023-0063 -> Fixed by upgrading to v1.16 solana, ignored by solana-labs before v1.16: https://github.com/solana-labs/solana/pull/33355
+        # - RUSTSEC-2023-0065 -> Only a problem on solana-program-test, used for local testing only
         run: >
           cargo audit -c always
           --ignore RUSTSEC-2020-0071
           --ignore RUSTSEC-2022-0093
           --ignore RUSTSEC-2023-0001
+          --ignore RUSTSEC-2023-0052
           --ignore RUSTSEC-2023-0063
+          --ignore RUSTSEC-2023-0065

--- a/programs/uxd/src/error.rs
+++ b/programs/uxd/src/error.rs
@@ -72,7 +72,7 @@ pub enum UxdError {
     InvalidAuthority,
     #[msg("The Depository's controller doesn't match the provided Controller.")]
     InvalidController,
-    #[msg("The Depository provided is not registered with the Controller.")]
+    #[msg("The Depository provided is not matching the one stored in the Controller.")]
     InvalidDepository,
     #[msg("The provided collateral mint does not match the depository's collateral mint.")]
     InvalidCollateralMint,

--- a/programs/uxd/src/instructions/credix_lp/collect_profits_of_credix_lp_depository.rs
+++ b/programs/uxd/src/instructions/credix_lp/collect_profits_of_credix_lp_depository.rs
@@ -31,7 +31,7 @@ pub struct CollectProfitsOfCredixLpDepository<'info> {
         mut,
         seeds = [CONTROLLER_NAMESPACE],
         bump = controller.load()?.bump,
-        constraint = controller.load()?.registered_credix_lp_depositories.contains(&depository.key()) @UxdError::InvalidDepository,
+        constraint = controller.load()?.credix_lp_depository == depository.key() @UxdError::InvalidDepository,
     )]
     pub controller: AccountLoader<'info, Controller>,
 

--- a/programs/uxd/src/instructions/credix_lp/edit_credix_lp_depository.rs
+++ b/programs/uxd/src/instructions/credix_lp/edit_credix_lp_depository.rs
@@ -21,7 +21,6 @@ pub struct EditCredixLpDepository<'info> {
         mut,
         seeds = [CONTROLLER_NAMESPACE],
         bump = controller.load()?.bump,
-        constraint = controller.load()?.registered_credix_lp_depositories.contains(&depository.key()) @UxdError::InvalidDepository,
         has_one = authority @UxdError::InvalidAuthority,
     )]
     pub controller: AccountLoader<'info, Controller>,

--- a/programs/uxd/src/instructions/credix_lp/mint_with_credix_lp_depository.rs
+++ b/programs/uxd/src/instructions/credix_lp/mint_with_credix_lp_depository.rs
@@ -47,7 +47,7 @@ pub struct MintWithCredixLpDepository<'info> {
         mut,
         seeds = [CONTROLLER_NAMESPACE],
         bump = controller.load()?.bump,
-        constraint = controller.load()?.registered_credix_lp_depositories.contains(&depository.key()) @UxdError::InvalidDepository,
+        constraint = controller.load()?.credix_lp_depository == depository.key() @UxdError::InvalidDepository,
         has_one = redeemable_mint @UxdError::InvalidRedeemableMint
     )]
     pub controller: AccountLoader<'info, Controller>,

--- a/programs/uxd/src/instructions/credix_lp/redeem_from_credix_lp_depository.rs
+++ b/programs/uxd/src/instructions/credix_lp/redeem_from_credix_lp_depository.rs
@@ -39,7 +39,7 @@ pub struct RedeemFromCredixLpDepository<'info> {
         mut,
         seeds = [CONTROLLER_NAMESPACE],
         bump = controller.load()?.bump,
-        constraint = controller.load()?.registered_credix_lp_depositories.contains(&depository.key()) @UxdError::InvalidDepository,
+        constraint = controller.load()?.credix_lp_depository == depository.key() @UxdError::InvalidDepository,
         has_one = redeemable_mint @UxdError::InvalidRedeemableMint
     )]
     pub controller: AccountLoader<'info, Controller>,

--- a/programs/uxd/src/instructions/credix_lp/register_credix_lp_depository.rs
+++ b/programs/uxd/src/instructions/credix_lp/register_credix_lp_depository.rs
@@ -150,12 +150,6 @@ pub(crate) fn handler(
     // Profits collection
     depository.profits_total_collected = u128::MIN;
 
-    // Add the depository to the controller
-    ctx.accounts
-        .controller
-        .load_mut()?
-        .add_registered_credix_lp_depository_entry(ctx.accounts.depository.key())?;
-
     // Emit event
     emit!(RegisterCredixLpDepositoryEvent {
         controller_version: ctx.accounts.controller.load()?.version,

--- a/programs/uxd/src/instructions/edit_mercurial_vault_depository.rs
+++ b/programs/uxd/src/instructions/edit_mercurial_vault_depository.rs
@@ -22,7 +22,6 @@ pub struct EditMercurialVaultDepository<'info> {
         seeds = [CONTROLLER_NAMESPACE],
         bump = controller.load()?.bump,
         has_one = authority @UxdError::InvalidAuthority,
-        constraint = controller.load()?.registered_mercurial_vault_depositories.contains(&depository.key()) @UxdError::InvalidDepository
     )]
     pub controller: AccountLoader<'info, Controller>,
 

--- a/programs/uxd/src/instructions/mercurial/collect_profits_of_mercurial_vault_depository.rs
+++ b/programs/uxd/src/instructions/mercurial/collect_profits_of_mercurial_vault_depository.rs
@@ -25,7 +25,7 @@ pub struct CollectProfitsOfMercurialVaultDepository<'info> {
         mut,
         seeds = [CONTROLLER_NAMESPACE],
         bump = controller.load()?.bump,
-        constraint = controller.load()?.registered_mercurial_vault_depositories.contains(&depository.key()) @UxdError::InvalidDepository,
+        constraint = controller.load()?.mercurial_vault_depository == depository.key() @UxdError::InvalidDepository,
     )]
     pub controller: AccountLoader<'info, Controller>,
 

--- a/programs/uxd/src/instructions/mercurial/mint_with_mercurial_vault_depository.rs
+++ b/programs/uxd/src/instructions/mercurial/mint_with_mercurial_vault_depository.rs
@@ -40,7 +40,7 @@ pub struct MintWithMercurialVaultDepository<'info> {
         mut,
         seeds = [CONTROLLER_NAMESPACE],
         bump = controller.load()?.bump,
-        constraint = controller.load()?.registered_mercurial_vault_depositories.contains(&depository.key()) @UxdError::InvalidDepository,
+        constraint = controller.load()?.mercurial_vault_depository == depository.key() @UxdError::InvalidDepository,
         has_one = redeemable_mint @UxdError::InvalidRedeemableMint
     )]
     pub controller: AccountLoader<'info, Controller>,

--- a/programs/uxd/src/instructions/mercurial/redeem_from_mercurial_vault_depository.rs
+++ b/programs/uxd/src/instructions/mercurial/redeem_from_mercurial_vault_depository.rs
@@ -39,7 +39,7 @@ pub struct RedeemFromMercurialVaultDepository<'info> {
         mut,
         seeds = [CONTROLLER_NAMESPACE],
         bump = controller.load()?.bump,
-        constraint = controller.load()?.registered_mercurial_vault_depositories.contains(&depository.key()) @UxdError::InvalidDepository,
+        constraint = controller.load()?.mercurial_vault_depository == depository.key() @UxdError::InvalidDepository,
         has_one = redeemable_mint @UxdError::InvalidRedeemableMint
     )]
     pub controller: AccountLoader<'info, Controller>,

--- a/programs/uxd/src/instructions/register_mercurial_vault_depository.rs
+++ b/programs/uxd/src/instructions/register_mercurial_vault_depository.rs
@@ -130,12 +130,6 @@ pub fn handler(
     // enable minting by default
     depository.minting_disabled = false;
 
-    // 2 - Update Controller state
-    ctx.accounts
-        .controller
-        .load_mut()?
-        .add_registered_mercurial_vault_depository_entry(ctx.accounts.depository.key())?;
-
     // 3 - Emit event
     emit!(RegisterMercurialVaultDepositoryEvent {
         version: ctx.accounts.controller.load()?.version,

--- a/programs/uxd/src/state/controller.rs
+++ b/programs/uxd/src/state/controller.rs
@@ -1,12 +1,8 @@
 use std::mem::size_of;
 
-use crate::error::UxdError;
 use crate::utils::checked_add;
 use crate::utils::checked_add_u128_and_i128;
 use anchor_lang::prelude::*;
-
-pub const MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES: usize = 4;
-pub const MAX_REGISTERED_CREDIX_LP_DEPOSITORIES: usize = 4;
 
 // Total should be 885 bytes
 pub const CONTROLLER_RESERVED_SPACE: usize = 94;
@@ -23,11 +19,7 @@ pub const CONTROLLER_SPACE: usize = 8
     + size_of::<u128>() // redeemable_global_supply_cap
     + 8 // _unused3
     + size_of::<u128>() // redeemable_circulating_supply
-    + 8 // _unused4
-    + size_of::<Pubkey>() * MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES // registered_mercurial_vault_depositories
-    + size_of::<u8>() // registered_mercurial_vault_depositories_count
-    + size_of::<Pubkey>() * MAX_REGISTERED_CREDIX_LP_DEPOSITORIES // registered_credix_lp_depositories
-    + size_of::<u8>() // registered_credix_lp_depositories_count
+    + 266 // _unused4
     + size_of::<u128>() // profits_total_collected
     + size_of::<u16>() // identity_depository_weight_bps
     + size_of::<u16>() // mercurial_vault_depository_weight_bps
@@ -76,16 +68,8 @@ pub struct Controller {
     // This should always be equal to the sum of all Depositories' `redeemable_amount_under_management`
     //  in redeemable Redeemable Native Amount
     pub redeemable_circulating_supply: u128,
-    pub _unused4: [u8; 8],
-    //
-    // The Mercurial Vault Depositories registered with this Controller
-    pub registered_mercurial_vault_depositories:
-        [Pubkey; MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES],
-    pub registered_mercurial_vault_depositories_count: u8,
-    //
-    // The Credix Lp Depositories registered with this Controller
-    pub registered_credix_lp_depositories: [Pubkey; MAX_REGISTERED_CREDIX_LP_DEPOSITORIES],
-    pub registered_credix_lp_depositories_count: u8,
+    // Padding for data that is no longer needed
+    pub _unused4: [u8; 266],
     //
     // Total amount of profits collected into the treasury by any depository
     pub profits_total_collected: u128,
@@ -112,43 +96,6 @@ pub struct Controller {
 }
 
 impl Controller {
-    pub fn add_registered_mercurial_vault_depository_entry(
-        &mut self,
-        mercurial_vault_depository_id: Pubkey,
-    ) -> Result<()> {
-        let current_size = usize::from(self.registered_mercurial_vault_depositories_count);
-        require!(
-            current_size < MAX_REGISTERED_MERCURIAL_VAULT_DEPOSITORIES,
-            UxdError::MaxNumberOfMercurialVaultDepositoriesRegisteredReached
-        );
-        // Increment registered Mercurial Pool Depositories count
-        self.registered_mercurial_vault_depositories_count =
-            checked_add(self.registered_mercurial_vault_depositories_count, 1)?;
-        // Add the new Mercurial Vault Depository ID to the array of registered Depositories
-        let new_entry_index = current_size;
-        self.registered_mercurial_vault_depositories[new_entry_index] =
-            mercurial_vault_depository_id;
-        Ok(())
-    }
-
-    pub(crate) fn add_registered_credix_lp_depository_entry(
-        &mut self,
-        credix_lp_depository_id: Pubkey,
-    ) -> Result<()> {
-        let current_size = usize::from(self.registered_credix_lp_depositories_count);
-        require!(
-            current_size < MAX_REGISTERED_CREDIX_LP_DEPOSITORIES,
-            UxdError::MaxNumberOfCredixLpDepositoriesRegisteredReached
-        );
-        // Increment registered Credix Lp Depositories count
-        self.registered_credix_lp_depositories_count =
-            checked_add(self.registered_credix_lp_depositories_count, 1)?;
-        // Add the new Credix Lp Depository ID to the array of registered Depositories
-        let new_entry_index = current_size;
-        self.registered_credix_lp_depositories[new_entry_index] = credix_lp_depository_id;
-        Ok(())
-    }
-
     // provides numbers + or - depending on the change
     pub fn update_onchain_accounting_following_mint_or_redeem(
         &mut self,

--- a/programs/uxd/tests/integration_tests/api/program_uxd/procedures/process_deploy_program.rs
+++ b/programs/uxd/tests/integration_tests/api/program_uxd/procedures/process_deploy_program.rs
@@ -222,8 +222,8 @@ pub async fn process_deploy_program(
     // Make sure the controller has the proper router depositories set
     program_uxd::procedures::process_set_router_depositories(
         program_context,
-        &payer,
-        &authority,
+        payer,
+        authority,
         &collateral_mint.pubkey(),
     )
     .await?;

--- a/programs/uxd/tests/integration_tests/api/program_uxd/procedures/process_deploy_program.rs
+++ b/programs/uxd/tests/integration_tests/api/program_uxd/procedures/process_deploy_program.rs
@@ -219,6 +219,15 @@ pub async fn process_deploy_program(
     )
     .await?;
 
+    // Make sure the controller has the proper router depositories set
+    program_uxd::procedures::process_set_router_depositories(
+        program_context,
+        &payer,
+        &authority,
+        &collateral_mint.pubkey(),
+    )
+    .await?;
+
     // Done
     Ok(())
 }

--- a/programs/uxd/tests/integration_tests/suites/test_mint_and_redeem.rs
+++ b/programs/uxd/tests/integration_tests/suites/test_mint_and_redeem.rs
@@ -1,7 +1,7 @@
 use solana_program_test::tokio;
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signer::keypair::Keypair;
 use solana_sdk::signer::Signer;
-use solana_sdk::pubkey::Pubkey;
 
 use uxd::instructions::EditControllerFields;
 use uxd::instructions::EditCredixLpDepositoryFields;
@@ -188,26 +188,26 @@ async fn test_mint_and_redeem() -> Result<(), program_context::ProgramError> {
     // -- Verify that mint is not possible until we set the depositories address on controller
     // ---------------------------------------------------------------------
 
-        // Artificially unset the router_depositories
-        program_uxd::instructions::process_edit_controller(
-            &mut program_context,
-            &payer,
-            &authority,
-            &EditControllerFields {
-                redeemable_global_supply_cap: None,
-                depositories_routing_weight_bps: None,
-                router_depositories: Some(EditRouterDepositories{
-                    identity_depository: Pubkey::default(),
-                    mercurial_vault_depository: Pubkey::default(),
-                    credix_lp_depository: Pubkey::default(),
-                }),
-                outflow_limit_per_epoch_amount: None,
-                outflow_limit_per_epoch_bps: None,
-                slots_per_epoch: None,
-            },
-        )
-        .await?;
-    
+    // Artificially unset the router_depositories
+    program_uxd::instructions::process_edit_controller(
+        &mut program_context,
+        &payer,
+        &authority,
+        &EditControllerFields {
+            redeemable_global_supply_cap: None,
+            depositories_routing_weight_bps: None,
+            router_depositories: Some(EditRouterDepositories {
+                identity_depository: Pubkey::default(),
+                mercurial_vault_depository: Pubkey::default(),
+                credix_lp_depository: Pubkey::default(),
+            }),
+            outflow_limit_per_epoch_amount: None,
+            outflow_limit_per_epoch_bps: None,
+            slots_per_epoch: None,
+        },
+    )
+    .await?;
+
     // Minting should fail now, as the depositories are not set yet
     assert!(program_uxd::instructions::process_mint(
         &mut program_context,

--- a/tests/api.ts
+++ b/tests/api.ts
@@ -190,6 +190,16 @@ export async function editController({
   controller: Controller;
   uiFields: {
     redeemableGlobalSupplyCap?: number;
+    depositoriesRoutingWeightBps?: {
+      identityDepositoryWeightBps: number;
+      mercurialVaultDepositoryWeightBps: number;
+      credixLpDepositoryWeightBps: number;
+    };
+    routerDepositories?: {
+      identityDepository: PublicKey;
+      mercurialVaultDepository: PublicKey;
+      credixLpDepository: PublicKey;
+    };
   };
 }): Promise<string> {
   const editControllerIx = uxdClient.createEditControllerInstruction(

--- a/tests/cases/editControllerTest.ts
+++ b/tests/cases/editControllerTest.ts
@@ -1,4 +1,4 @@
-import { Signer } from '@solana/web3.js';
+import { PublicKey, Signer } from '@solana/web3.js';
 import { Controller, nativeToUi } from '@uxd-protocol/uxd-client';
 import { expect } from 'chai';
 import { editController } from '../api';
@@ -14,6 +14,16 @@ export const editControllerTest = async function ({
   controller: Controller;
   uiFields: {
     redeemableGlobalSupplyCap?: number;
+    depositoriesRoutingWeightBps?: {
+      identityDepositoryWeightBps: number;
+      mercurialVaultDepositoryWeightBps: number;
+      credixLpDepositoryWeightBps: number;
+    };
+    routerDepositories?: {
+      identityDepository: PublicKey;
+      mercurialVaultDepository: PublicKey;
+      credixLpDepository: PublicKey;
+    };
   };
 }) {
   const connection = getConnection();

--- a/tests/suite/controllerIntegrationSuite.ts
+++ b/tests/suite/controllerIntegrationSuite.ts
@@ -1,6 +1,10 @@
 import { Signer } from '@solana/web3.js';
 import { Controller } from '@uxd-protocol/uxd-client';
 import { initializeControllerTest } from '../cases/initializeControllerTest';
+import { editControllerTest } from '../cases/editControllerTest';
+import { createIdentityDepositoryDevnet } from '../utils';
+import { createCredixLpDepositoryDevnetUSDC } from '../utils';
+import { createMercurialVaultDepositoryDevnet } from '../utils';
 
 export class controllerIntegrationSuiteParameters {
   public globalSupplyCap: number;
@@ -25,4 +29,22 @@ export const controllerIntegrationSuite = function ({
       controller,
       payer,
     }));
+
+  it('Initialize router depositories', async function () {
+    const identityDepository = createIdentityDepositoryDevnet();
+    const credixLpDepository = await createCredixLpDepositoryDevnetUSDC();
+    const mercurialVaultDepository =
+      await createMercurialVaultDepositoryDevnet();
+    editControllerTest({
+      authority,
+      controller,
+      uiFields: {
+        routerDepositories: {
+          identityDepository: identityDepository.pda,
+          mercurialVaultDepository: mercurialVaultDepository.pda,
+          credixLpDepository: credixLpDepository.pda,
+        },
+      },
+    });
+  });
 };


### PR DESCRIPTION
Originally reported by @acamill , we could deprecate the use of "registered" depositories, and instead only enable mint/redeem for the router configured depositories instead, this would avoid having to "double register" both for the controller and for the router each depositories